### PR TITLE
Update 02-installing.asc

### DIFF
--- a/book/01-introduction/sections/02-installing.asc
+++ b/book/01-introduction/sections/02-installing.asc
@@ -68,13 +68,33 @@ Note that there are some limitations to portable mode:
 
 To install Atom on Linux, you can download a https://atom.io/download/deb[Debian package] or https://atom.io/download/rpm[RPM package] either from the https://atom.io[main Atom website] at atom.io or from the Atom project releases page at https://github.com/atom/atom/releases.
 
-On Debian, you would install the Debian package with `dpkg -i`:
+===== Debian
+To install Atom on Debian / Ubuntu / related systems, run:
 
   $ sudo dpkg -i atom-amd64.deb
+  $ sudo apt-get -f install
+  
+the final line is designed to install the binary's dependencies if they are missing. 
 
-On RedHat or another RPM based system, you would use the `rpm -i` command:
+===== CentOS / Oracle Linux / Red Hat Enterprise Linux / Scientific Linux
+On Enterprise RedHat Linux systems that still use the yum package manager, run:
 
-  $ rpm -i atom.x86_64.rpm
+  $ sudo yum install -y atom.x86_64.rpm
+  
+
+to install Atom. if you want to download and install the latest RPM binary in a single line, run:
+
+  $ sudo yum install -y https://github.com/atom/atom/archive/atom.x86_64.rpm
+
+===== Chapeau / Fedora / Korora
+To download and install the latest release of Atom on Fedora and other systems using the DNF package manager, run: 
+
+  $ sudo dnf install -y https://github.com/atom/atom/archive/atom.x86_64.rpm
+
+===== openSUSE / SUSE Linux Enterprise
+To download and install the latest release of Atom on openSUSE and other systems using the ZYpp package manager, run:
+
+  $ sudo zypper in -y https://github.com/atom/atom/archive/atom.x86_64.rpm
 
 ==== Atom from Source
 

--- a/book/01-introduction/sections/02-installing.asc
+++ b/book/01-introduction/sections/02-installing.asc
@@ -66,7 +66,7 @@ Note that there are some limitations to portable mode:
 
 ==== Atom on Linux
 
-To install Atom on Linux, you can download a https://atom.io/download/deb[Debian package] or https://atom.io/download/rpm[RPM package] either from the https://atom.io[main Atom website] at atom.io or from the Atom project releases page at https://github.com/atom/atom/releases.
+To install Atom on Linux, you can download a https://atom.io/download/deb[Debian package] or https://atom.io/download/rpm[RPM package] either from the https://atom.io[main Atom website] at atom.io or from the Atom project releases page at https://github.com/atom/atom/releases. These packages do not have auto-update features, however, so whenever a new release of Atom comes out that you would like to upgrade to, you will have to repeat this installation process again for the new release. 
 
 ===== Debian
 To install Atom on Debian / Ubuntu / related systems, run:


### PR DESCRIPTION
This pull request corresponds to issue #175. It does **NOT** include mention of the unofficial, distribution-specific, means of installing Atom on Linux. Like from the Arch User Repository, `sabayon` Gentoo overlay, *etc.*