### PR TITLE
Clearer list of activationHooks

### DIFF
--- a/content/hacking-atom/sections/package-word-count.asciidoc
+++ b/content/hacking-atom/sections/package-word-count.asciidoc
@@ -58,9 +58,7 @@ snippets your package needs to load. If not specified, snippets in the _snippets
 - `activationCommands`: an Object identifying commands that trigger your package's activation. The keys are CSS selectors, the values are Arrays of Strings identifying the command.
 The loading of your package is delayed until one of these events is triggered within the associated scope defined by the CSS selector.
 
-- `activationHooks`: an Array of Strings identifying hooks that trigger your package's activation. The loading of your package is delayed until one of these hooks are triggered.
-Known hooks are:
-  - `language-package-name:grammar-used` (e.g) `language-javascript:grammar-used`
+- `activationHooks`: an Array of Strings identifying hooks that trigger your package's activation. The loading of your package is delayed until one of these hooks are triggered. Currently, the only activation hook is `language-package-name:grammar-used` (e.g., `language-javascript:grammar-used`)
 
 The `package.json` in the package we've just generated looks like this currently:
 


### PR DESCRIPTION
The list of known activation hooks was previously confusing because the list had only one item, and when rendered showed up as a bullet point in the same level list of `package.json` properties.

The only hook I could find any mention of was the one that was already there, so I assume it's the only one. Changed the wording to indicate that.

Also made the use of e.g. clearer w/ parentheses.