### PR TITLE
Add contributing links and "improve this page" links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,13 @@
 # Contributing to the Atom Flight Manual
 
-Contributing is easy. Download this repository, make a change to the Asciidoc (or whatever you want to change), fork this repository, push it to a branch and send us a Pull Request.
+Contributing is easy!
+
+1. [Fork this repository](https://github.com/atom/flight-manual.atom.io#fork-destination-box)
+2. Download your fork. [(Click here for help)](https://help.github.com/articles/fork-a-repo/#keep-your-fork-synced)
+3. Create a named feature branch ([we use Github flow](https://guides.github.com/introduction/flow/index.html))
+4. Make a change to the Asciidoc (or whatever you want to change),
+5. push it to a branch
+6. send us a [Pull Request](https://github.com/atom/flight-manual.atom.io/pulls).
 
 If you're not sure about the change or the idea for the change, open an issue first to see if it's something we'll want to pull in. If you want to make some sort of sweeping grammatical or narrative change, please check with us first because we don't want you to do a ton of work and not get it merged.
 

--- a/assets/stylesheets/app/_flight_manual.scss
+++ b/assets/stylesheets/app/_flight_manual.scss
@@ -481,6 +481,17 @@ input.documents-search-input {
   }
 }
 
+// Adjustments for page-specific links to improve the docs
+$improve-link-separator-spacing: 1em;
+
+.article-title {
+  margin-right: $improve-link-separator-spacing / 2;
+}
+
+.improve-link {
+  margin-left: $improve-link-separator-spacing / 2;
+}
+
 /* syntax highlighting and coloring text in general */
 .document-content {
   padding-left:15px;

--- a/layouts/article.html
+++ b/layouts/article.html
@@ -16,7 +16,8 @@
           <% section = lookup_section('toc', @item[:title]) %>
           <h1>
             <span class="article-title"><%= section << ' ' << @item[:title] if section %></span>
-            <a class="improve-link" href="<%= "https://github.com/atom/flight-manual.atom.io/edit/master/content#{@item.identifier}" %>">
+            <a class="improve-link"
+                href="<%= "https://github.com/atom/flight-manual.atom.io/edit/master/content#{@item.identifier}" %>" data-proofer-ignore>
               <span class="octicon octicon-pencil"></span> Improve this page
             </a>
           </h1>

--- a/layouts/article.html
+++ b/layouts/article.html
@@ -14,10 +14,10 @@
         </div>
         <div class="markdown-body document-content">
           <% section = lookup_section('toc', @item[:title]) %>
-          <h1><%= section << ' ' << @item[:title] if section %></h1>
-          <h1 class="improve">
-            <a href="<%= "https://github.com/atom/flight-manual.atom.io/edit/master/content#{@item.identifier}" %>">
-              <span class="octicon octicon-pencil"></span>  Improve this page
+          <h1>
+            <span class="article-title"><%= section << ' ' << @item[:title] if section %></span>
+            <a class="improve-link" href="<%= "https://github.com/atom/flight-manual.atom.io/edit/master/content#{@item.identifier}" %>">
+              <span class="octicon octicon-pencil"></span> Improve this page
             </a>
           </h1>
           <%= yield %>

--- a/layouts/article.html
+++ b/layouts/article.html
@@ -15,9 +15,8 @@
         <div class="markdown-body document-content">
           <% section = lookup_section('toc', @item[:title]) %>
           <h1><%= section << ' ' << @item[:title] if section %></h1>
-          <% improve_this_page_url = "https://github.com/atom/flight-manual.atom.io/edit/master/content" + @item.identifier %>
           <h1 class="improve">
-            <a href="<%= improve_this_page_url %>">
+            <a href="<%= "https://github.com/atom/flight-manual.atom.io/edit/master/content" + @item.identifier %>">
               <span class="octicon octicon-pencil"></span>  Improve this page
             </a>
           </h1>

--- a/layouts/article.html
+++ b/layouts/article.html
@@ -16,7 +16,7 @@
           <% section = lookup_section('toc', @item[:title]) %>
           <h1><%= section << ' ' << @item[:title] if section %></h1>
           <h1 class="improve">
-            <a href="<%= "https://github.com/atom/flight-manual.atom.io/edit/master/content" + @item.identifier %>">
+            <a href="<%= "https://github.com/atom/flight-manual.atom.io/edit/master/content#{@item.identifier}" %>">
               <span class="octicon octicon-pencil"></span>  Improve this page
             </a>
           </h1>

--- a/layouts/article.html
+++ b/layouts/article.html
@@ -15,6 +15,12 @@
         <div class="markdown-body document-content">
           <% section = lookup_section('toc', @item[:title]) %>
           <h1><%= section << ' ' << @item[:title] if section %></h1>
+          <% improve_this_page_url = "https://github.com/atom/flight-manual.atom.io/edit/master/content" + @item.identifier %>
+          <h1 class="improve">
+            <a href="<%= improve_this_page_url %>">
+              <span class="octicon octicon-pencil"></span>  Improve this page
+            </a>
+          </h1>
           <%= yield %>
         </div>
       </div>

--- a/layouts/includes/bottom_bar.html
+++ b/layouts/includes/bottom_bar.html
@@ -8,6 +8,7 @@
         <li><a href="https://atom.io/releases">Releases</a></li>
         <li><a href="https://atom.io/faq">FAQ</a></li>
         <li><a href="https://atom.io/contact">Contact</a></li>
+        <li><a href="https://github.com/atom/flight-manual.atom.io/blob/master/CONTRIBUTING.md">Contribute!</a></li>
       </ul>
 
       <div class="footer-right">


### PR DESCRIPTION
## Background

Several potential contributors [had trouble finding this repository](https://github.com/atom/flight-manual.atom.io/issues/176). We discussed some possible changes to make it easier to go from *viewing* the Atom docs to *proposing edits* to them. 

## What I'm proposing with this PR

- Add a "contribute!" link to the bottom bar of each docs page.
- Add explanatory links to the overview of CONTRIBUTING.md

## This is effectively my first PR on an open-source project

Please be kind O:-)