### PR TITLE
Switch to modern smart quote syntax

### DIFF
--- a/content/hacking-atom/index.asciidoc
+++ b/content/hacking-atom/index.asciidoc
@@ -4,7 +4,7 @@ title: Hacking Atom
 [[_hacking]]
 == Hacking Atom
 
-Now it's time to come to the ``Hackable'' part of the Hackable Editor. As we've seen throughout the second section, a huge part of Atom is made up of bundled packages. If you wish to add some functionality to Atom, you have access to the same APIs and tools that the core features of Atom has. From the https://github.com/atom/tree-view[tree view] to the https://github.com/atom/command-palette[command palette] to https://github.com/atom/find-and-replace[find and replace] functionality, even the most core features of Atom are implemented as packages.
+Now it's time to come to the "`Hackable`" part of the Hackable Editor. As we've seen throughout the second section, a huge part of Atom is made up of bundled packages. If you wish to add some functionality to Atom, you have access to the same APIs and tools that the core features of Atom has. From the https://github.com/atom/tree-view[tree view] to the https://github.com/atom/command-palette[command palette] to https://github.com/atom/find-and-replace[find and replace] functionality, even the most core features of Atom are implemented as packages.
 
 In this chapter, we're going to learn how to extend the functionality of Atom through writing packages. This will be everything from new user interfaces to new language grammars to new themes. We'll learn this by writing a series of increasingly complex packages together, introducing you to new APIs and tools and techniques as we need them.
 


### PR DESCRIPTION
See http://asciidoctor.org/docs/migration/#migration-cheatsheet for details. Asciidoctor is now using the modern syntax everywhere by default (unless you explicitly enable compat-mode).