### PR TITLE
Fix typo in service doc

### DIFF
--- a/content/behind-atom/sections/interacting-with-other-packages-via-services.asciidoc
+++ b/content/behind-atom/sections/interacting-with-other-packages-via-services.asciidoc
@@ -9,7 +9,7 @@ Atom packages can interact with each other through versioned APIs called _servic
       "description": "Does a useful thing",
       "versions": {
         "1.2.3": "provideMyServiceV1",
-        "2.3.4": "provideMyServiceV2",
+        "2.3.4": "provideMyServiceV2"
       }
     }
   }
@@ -37,7 +37,7 @@ Similarly, to consume a service, specify one or more https://docs.npmjs.com/misc
     "another-service": {
       "versions": {
         "^1.2.3": "consumeAnotherServiceV1",
-        ">=2.3.4 <2.5": "consumeAnotherServiceV2",
+        ">=2.3.4 <2.5": "consumeAnotherServiceV2"
       }
     }
   }


### PR DESCRIPTION
Found a small syntax error in [Chapter 4: Interacting With Other Packages Via Services](http://flight-manual.atom.io/behind-atom/sections/interacting-with-other-packages-via-services/):

![screenshot_2016-04-11_14-04-39](https://cloud.githubusercontent.com/assets/7817714/14426319/77e5c7aa-ffee-11e5-8d8a-c6649a31dcbd.png)
