### PR TITLE
Update descriptive title for example package

### DIFF
--- a/content/hacking-atom/sections/package-word-count.asciidoc
+++ b/content/hacking-atom/sections/package-word-count.asciidoc
@@ -1,5 +1,5 @@
 ---
-title: "Package: Word Count"
+title: "Create and Publish an Example Package: Word Count"
 ---
 [[_package_word_count]]
 === Package: Word Count


### PR DESCRIPTION
Basically someone asked on the forum how to publish a package, but:

- The table of content don't contain the word "publish".
- This page show up in search, I first dismissed it because I interpreted  "Package: Word count" as I would have interpreted "Package: Fuzzy Finder", that is: an explanation of some bundled package in atom.

On earlier version of atom flight manual this link pointed to somewhere.

https://atom.io/docs/v0.94.0/publishing-a-package 

I find this structure very descriptive to the goal intended. Reading the link explain it. 
This description power is somewhat lost using

http://flight-manual.atom.io/hacking-atom/sections/package-word-count

---

I'll end with the fact I'm not a native English speaker, so I don't expect my title to be retained, simply want to raise awareness that the current title make it hard to guess what this section is about.