### PR TITLE
swap order of keybindings, to keep things consistent

### DIFF
--- a/content/using-atom/sections/moving-in-atom.asciidoc
+++ b/content/using-atom/sections/moving-in-atom.asciidoc
@@ -9,8 +9,8 @@ First of all, Atom ships with many of the basic Emacs keybindings for navigating
 
 In addition to single character movement, there are a number of other movement keybindings.
 
-`alt-B`, `alt-left`:: Move to beginning of word
-`alt-F`, `alt-right`:: Move to end of word
+`alt-left`, `alt-B`:: Move to beginning of word
+`alt-right`, `alt-F`:: Move to end of word
 `cmd-right`, `ctrl-E`:: Move to end of line
 `cmd-left`, `ctrl-A`:: Move to first character of line
 `cmd-up`:: Move to top of file

--- a/content/using-atom/sections/moving-in-atom.asciidoc
+++ b/content/using-atom/sections/moving-in-atom.asciidoc
@@ -11,8 +11,8 @@ In addition to single character movement, there are a number of other movement k
 
 `alt-left`, `alt-B`:: Move to beginning of word
 `alt-right`, `alt-F`:: Move to end of word
-`cmd-right`, `ctrl-E`:: Move to end of line
 `cmd-left`, `ctrl-A`:: Move to first character of line
+`cmd-right`, `ctrl-E`:: Move to end of line
 `cmd-up`:: Move to top of file
 `cmd-down`:: Move to bottom of file
 


### PR DESCRIPTION
Now columns are consistent, all the arrow-key bindings are on the left side.

I'm fine with the Emacs bindings first, just want consistency.