### PR TITLE
Add title to page

### DIFF
--- a/content/behind-atom/sections/interacting-with-other-packages-via-services.asciidoc
+++ b/content/behind-atom/sections/interacting-with-other-packages-via-services.asciidoc
@@ -1,3 +1,6 @@
+---
+title: Interacting With Other Packages Via Services
+---
 === Interacting With Other Packages Via Services
 
 Atom packages can interact with each other through versioned APIs called _services_. To provide a service, in your `package.json`, specify one or more version numbers, each paired with the name of a method on your package's main module:


### PR DESCRIPTION
Fixes #202 

Each page requires a title (that matches) in order for the table of contents to render properly.