### PR TITLE
Change .asc to .asciidoc in README.md and outline.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This book is open source under a Creative Commons license.
 
 ## License
 
-This book is published under the Creative Commons BY-SA license. If you contribute to the work, you will have to agree to allow your content to be published under the self same license. Check out [the license file](LICENSE.asc) for more details.
+This book is published under the Creative Commons BY-SA license. If you contribute to the work, you will have to agree to allow your content to be published under the self same license. Check out [the license file](LICENSE.asciidoc) for more details.
 
 ## Current Progress
 

--- a/outline.md
+++ b/outline.md
@@ -4,7 +4,7 @@ done.  We'll remove lines from this when each section is completed so we
 only have what it left to do here.
 
 You'll notice in some of the active `book/[section]/sections/` folders
-there are some `xx-name.asc` files. These are sections of content that
+there are some `xx-name.asciidoc` files. These are sections of content that
 should probably be folded in at some point but we're not sure exactly where
 to put them. They aren't included in any of the main files, so they aren't
 currently rendered. If you want to write something and aren't sure where it


### PR DESCRIPTION
In `README.md` the link to the licence used the file extension `.asc`, rather than the new `.asciidoc` extension implemented in @54e76320c6d599cd63b11d46acdf251c1b298228.
 In `outline.md`, the introduction referenced files with a `.asc` extension instead of files with a `.asciidoc` extension. What I've done here is simply fix both of these issues, both files now use `.asciidoc`.