### PR TITLE
Don't upgrade to nanoc v4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source 'https://rubygems.org'
 ruby '2.2.3'
 
 # essential
-gem 'nanoc', '~> 4.1'
+# Until https://github.com/gjtorikian/nanoc-conref-fs/issues/5 is fixed, can't update to v4.2
+gem 'nanoc', ['>= 4.1', '< 4.2']
 gem 'nanoc-conref-fs', '~> 0.5'
 
 # rendering

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ DEPENDENCIES
   html-pipeline-asciidoc_filter (~> 1.5)
   html-pipeline-rouge_filter (~> 1.0)
   html-proofer (~> 3.0)
-  nanoc (~> 4.1)
+  nanoc (>= 4.1, < 4.2)
   nanoc-conref-fs (~> 0.5)
   nanoc-html-pipeline (= 0.3.3)
   rake

--- a/content/using-atom/sections/moving-in-atom.md
+++ b/content/using-atom/sections/moving-in-atom.md
@@ -46,7 +46,7 @@ You can also jump around a little more informatively with the Symbols View. To j
 
 ![Search by symbol across your project](../../images/symbol.png)
 
-You can generate a `tags` file by using the [ctags utility](http://ctags.sourceforge.net). Once it is installed, you can use it to generate a `tags` file by running a command to generate it. See the [ctags documentation](http://ctags.sourceforge.net/ctags.html) for details.
+You can generate a `tags` file by using the [ctags utility](https://ctags.io/). Once it is installed, you can use it to generate a `tags` file by running a command to generate it. See the [ctags documentation](http://docs.ctags.io/en/latest/) for details.
 
 Once you have your `tags` file generated, you can use it to search for symbols across your project by pressing <kbd class="platform-mac">Cmd+Shift+R</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+R</kbd>. This also enables you to use <kbd class="platform-mac">Alt+Cmd+Down</kbd><kbd class="platform-windows platform-linux">Alt+Ctrl+Down</kbd> to go to and <kbd class="platform-mac">Alt+Cmd+Up</kbd><kbd class="platform-windows platform-linux">Alt+Ctrl+Up</kbd> to return from the declaration of the symbol under the cursor.
 


### PR DESCRIPTION
Fixes #205

Since the version of nanoc we're currently using works fine for our purposes, we'll stick with v4.1.x for now until gjtorikian/nanoc-conref-fs#5 is fixed.