### PR TITLE
Fix oversized footer on root page

### DIFF
--- a/assets/stylesheets/app/_index.scss
+++ b/assets/stylesheets/app/_index.scss
@@ -12,18 +12,21 @@
   h3 a {
     color: inherit;
   }
-  ul {
-    list-style-type: none;
-    margin: 0;
-    margin-left: 15px;
-    padding: 0;
-    li {
-      margin-top: 4px;
-      font-size: 1.2em;
-      small {
-        font-size: 0.9em;
-        color: #666;
-        margin-right: 10px;
+
+  .markdown-body {
+    ul {
+      list-style-type: none;
+      margin: 0;
+      margin-left: 15px;
+      padding: 0;
+      li {
+        margin-top: 4px;
+        font-size: 1.2em;
+        small {
+          font-size: 0.9em;
+          color: #666;
+          margin-right: 10px;
+        }
       }
     }
   }


### PR DESCRIPTION
Added an extra guard to ensure that the TOC style doesn't bleed over into the footer.

/cc @simurai Not sure if this is the best way to do this, though it appears effective. 💭 ?