### PR TITLE
Restyle platform-nav

### DIFF
--- a/assets/javascripts/platform-nav.js
+++ b/assets/javascripts/platform-nav.js
@@ -48,7 +48,7 @@
 
   window.initPlatformNav = function () {
     var $platformNav = $('#platform-nav')
-    $platformNav.show()
+    $platformNav.addClass('show')
     $platformNav.find('a').click(function () {
       updateArticlePlatform($(this).data('platform'))
     })

--- a/assets/stylesheets/app/_flight_manual.scss
+++ b/assets/stylesheets/app/_flight_manual.scss
@@ -475,7 +475,7 @@ input.documents-search-input {
       padding: 1px;
       padding-left: 30px;
       text-indent: -15px;
-      
+
       &.selected {
         background: #eee;
       }
@@ -484,14 +484,9 @@ input.documents-search-input {
 }
 
 // Adjustments for page-specific links to improve the docs
-$improve-link-separator-spacing: 1em;
-
-.article-title {
-  margin-right: $improve-link-separator-spacing / 2;
-}
 
 .improve-link {
-  margin-left: $improve-link-separator-spacing / 2;
+  margin-left: 2em;
 }
 
 h1.document-title {

--- a/assets/stylesheets/app/_platform_nav.scss
+++ b/assets/stylesheets/app/_platform_nav.scss
@@ -34,9 +34,11 @@ body {
   display: none;
   text-align: right;
   text-transform: uppercase;
+
   &.show {
     display: inline-block;
   }
+
   ul {
     display: inline-block;
     margin: 0;
@@ -45,34 +47,22 @@ body {
     list-style-type: none;
 
     li {
-      display: inline;
-      padding-bottom: 5px;
-
-      a, a:visited {
-        border-left: 1px solid #999;
-        padding-left: 5px;
-        padding-right: 5px;
-        text-decoration: none;
-      }
+      display: inline-block;
 
       &.hidden {
         display: none;
       }
 
-      &.selected {
-        color: $brownDark;
-        cursor: default;
-        background: url(/assets/images/site/under-triangle.gif) center bottom no-repeat;
-
-        a {
-          color: $brownDark;
-        }
+      a {
+        margin: 0 .25em;
+        padding: .15em 0;
+        text-decoration: none;
       }
 
-      &:first-child {
-        a {
-          border: none;
-        }
+      &.selected a {
+        color: $brownDark;
+        border-bottom: 1px solid $border-color;
+        cursor: default;
       }
     }
   }

--- a/assets/stylesheets/app/_platform_nav.scss
+++ b/assets/stylesheets/app/_platform_nav.scss
@@ -34,8 +34,13 @@ body {
   display: none;
   text-align: right;
   text-transform: uppercase;
-
+  &.show {
+    display: inline-block;
+  }
   ul {
+    display: inline-block;
+    margin: 0;
+    padding: 0;
     font-size: 80%;
     list-style-type: none;
 

--- a/layouts/article.html
+++ b/layouts/article.html
@@ -18,7 +18,6 @@
 
         <% section = lookup_section('toc', @item[:title]) %>
         <h1 class="document-title">
-          <span class="article-title"><%= section << ' ' << @item[:title] if section %></span>
           <a class="improve-link"
               href="<%= "https://github.com/atom/flight-manual.atom.io/edit/master/content#{@item.identifier}" %>" data-proofer-ignore>
             <span class="octicon octicon-pencil"></span> Improve this page

--- a/layouts/article.html
+++ b/layouts/article.html
@@ -14,10 +14,9 @@
           <%= renderp '/includes/toc.html', :heading => 'h4', :title => @item[:title] %>
         </div>
 
-        <%= renderp '/includes/platform-nav.html' %>
-
         <% section = lookup_section('toc', @item[:title]) %>
         <h1 class="document-title">
+          <%= renderp '/includes/platform-nav.html' %>
           <a class="improve-link"
               href="<%= "https://github.com/atom/flight-manual.atom.io/edit/master/content#{@item.identifier}" %>" data-proofer-ignore>
             <span class="octicon octicon-pencil"></span> Improve this page

--- a/layouts/includes/platform-nav.html
+++ b/layouts/includes/platform-nav.html
@@ -1,4 +1,5 @@
 <div id="platform-nav">
+  <span class="octicon octicon-device-desktop"></span>
   <ul>
     <li class="platform-mac">
       <a href="#platform-mac" data-platform="mac">


### PR DESCRIPTION
This
- removes the article title (already shown)
- moves the platform-nav next to the "Improve this page" link
- restyles the platform-nav

Before | After
--- | ---
<img width="336" alt="screen shot 2016-08-04 at 5 37 01 pm" src="https://cloud.githubusercontent.com/assets/378023/17408250/c1fd98d2-5a6a-11e6-9859-a6fde36126e7.png"> | <img width="418" alt="screen shot 2016-08-04 at 5 36 46 pm" src="https://cloud.githubusercontent.com/assets/378023/17408258/ca738328-5a6a-11e6-843d-3e6ed7f65e29.png">

<img width="1065" alt="screen shot 2016-08-04 at 5 36 14 pm" src="https://cloud.githubusercontent.com/assets/378023/17408284/dd91edbe-5a6a-11e6-96c0-7ee78740276d.png">

Closes #249