### PR TITLE
Move the Publishing section to its own page

### DIFF
--- a/content/hacking-atom/sections/creating-a-theme.md
+++ b/content/hacking-atom/sections/creating-a-theme.md
@@ -157,4 +157,4 @@ Now if you mess up something, only the window in "Dev Mode"  will be affected an
 
 Once you're happy with your theme and would like to share it with other Atom users, it's time to publish it. :tada:
 
-Follow the steps in the [Publishing](http://flight-manual.atom.io/hacking-atom/sections/package-word-count/#publishing) section of the Word Count example. Publishing a theme works exactly the same.
+Follow the steps on the [Publishing](../publishing/) page. The example used is for the Word Count package, but publishing a theme works exactly the same.

--- a/content/hacking-atom/sections/package-word-count.md
+++ b/content/hacking-atom/sections/package-word-count.md
@@ -421,64 +421,6 @@ Once you've got your test suite written, you can run it by pressing <kbd class="
 
 You can also use the `atom --test spec` command to run them from the command line. It prints the test output and results to the console and returns the proper status code depending on whether the tests passed or failed.
 
-#### Publishing
-
-Now that our simple plugin is working and tested, let's go ahead and publish it so it's available to the world.
-
-Atom bundles a command line utility called `apm` which we first used back in [Command Line](/using-atom/sections/atom-packages/#command-line) to search for and install packages via the command line. The `apm` command can also be used to publish Atom packages to the public registry and update them.
-
-##### Prepare Your Package
-
-There are a few things you should double check before publishing:
-
-* Your `package.json` file has `name`, `description`, and `repository` fields.
-* Your `package.json` file has a `version` field with a value of  `"0.0.0"`.
-* Your `package.json` file has an `engines` field that contains an entry for Atom such as: `"engines": {"atom": ">=1.0.0 <2.0.0"}`.
-* Your package has a `README.md` file at the root.
-* Change the `repository` url in the `package.json` file to match the URL of your repository.
-* Your package is in a Git repository that has been pushed to [GitHub](https://github.com). Follow [this guide](http://guides.github.com/overviews/desktop) if your package isn't already on GitHub.
-
-##### Publish Your Package
-
-Before you publish a package it is a good idea to check ahead of time if a package with the same name has already been published to [the atom.io package registry](https://atom.io/packages). You can do that by visiting `https://atom.io/packages/your-name-word-count` to see if the package already exists. If it does, update your package's name to something that is available before proceeding.
-
-Now let's review what the `apm publish` command does:
-
-1. Registers the package name on atom.io if it is being published for the first time.
-2. Updates the `version` field in the `package.json` file and commits it.
-3. Creates a new [Git tag](http://git-scm.com/book/en/Git-Basics-Tagging) for the version being published.
-4. Pushes the tag and current branch up to GitHub.
-5. Updates atom.io with the new version being published.
-
-Now run the following commands to publish your package:
-
-``` command-line
-$ cd ~/github/my-package
-$ apm publish minor
-```
-
-If this is the first package you are publishing, the `apm publish` command may prompt you for your GitHub username and password. This is required to publish and you only need to enter this information the first time you publish. The credentials are stored securely in your [keychain](https://en.wikipedia.org/wiki/Keychain_(Apple)) once you login.
-
-Your package is now published and available on atom.io. Head on over to `https://atom.io/packages/your-name-word-count` to see your package's page.
-
-With `apm publish`, you can bump the version and publish by using
-
-``` command-line
-$ apm publish <version-type>
-```
-
-where `<version-type>` can be `major`, `minor` and `patch`.
-
-The `major` option to the publish command tells apm to increment the first number of the version before publishing so the published version will be `1.0.0` and the Git tag created will be `v1.0.0`.
-
-The `minor` option to the publish command tells apm to increment the second number of the version before publishing so the published version will be `0.1.0` and the Git tag created will be `v0.1.0`.
-
-The `patch` option to the publish command tells apm to increment the third number of the version before publishing so the published version will be `0.0.1` and the Git tag created will be `v0.0.1`.
-
-Use `major` when you make a change that breaks backwards compatibility, like changing defaults or removing features. Use `minor` when adding new functionality or making improvements on existing code. Use `patch` when you fix a bug that was causing incorrect behaviour. Check out [semantic versioning](http://semver.org) to learn more about best practices for versioning your package releases.
-
-You can also run `apm help publish` to see all the available options and `apm help` to see all the other available commands.
-
 #### Summary
 
-We've now generated, customized and published our first plugin for Atom. Congratulations! Now anyone can install our masterpiece from directly within Atom as we did in [Atom packages](/using-atom/sections/atom-packages/).
+We've now generated, customized and tested our first plugin for Atom. Congratulations! Now let's go ahead and [publish](../publishing/) it so it's available to the world.

--- a/content/hacking-atom/sections/publishing.md
+++ b/content/hacking-atom/sections/publishing.md
@@ -1,0 +1,59 @@
+---
+title: "Publishing"
+---
+
+### Publishing
+
+Atom bundles a command line utility called `apm` which we first used back in [Command Line](/using-atom/sections/atom-packages/#command-line) to search for and install packages via the command line. The `apm` command can also be used to publish Atom packages to the public registry and update them.
+
+#### Prepare Your Package
+
+There are a few things you should double check before publishing:
+
+* Your `package.json` file has `name`, `description`, and `repository` fields.
+* Your `package.json` file has a `version` field with a value of  `"0.0.0"`.
+* Your `package.json` file has an `engines` field that contains an entry for Atom such as: `"engines": {"atom": ">=1.0.0 <2.0.0"}`.
+* Your package has a `README.md` file at the root.
+* Change the `repository` url in the `package.json` file to match the URL of your repository.
+* Your package is in a Git repository that has been pushed to [GitHub](https://github.com). Follow [this guide](http://guides.github.com/overviews/desktop) if your package isn't already on GitHub.
+
+#### Publish Your Package
+
+Before you publish a package it is a good idea to check ahead of time if a package with the same name has already been published to [the atom.io package registry](https://atom.io/packages). You can do that by visiting `https://atom.io/packages/your-package-name` to see if the package already exists. If it does, update your package's name to something that is available before proceeding.
+
+Now let's review what the `apm publish` command does:
+
+1. Registers the package name on atom.io if it is being published for the first time.
+2. Updates the `version` field in the `package.json` file and commits it.
+3. Creates a new [Git tag](http://git-scm.com/book/en/Git-Basics-Tagging) for the version being published.
+4. Pushes the tag and current branch up to GitHub.
+5. Updates atom.io with the new version being published.
+
+Now run the following commands to publish your package:
+
+``` command-line
+$ cd ~/github/my-package
+$ apm publish minor
+```
+
+If this is the first package you are publishing, the `apm publish` command may prompt you for your GitHub username and password. This is required to publish and you only need to enter this information the first time you publish. The credentials are stored securely in your [keychain](https://en.wikipedia.org/wiki/Keychain_(Apple)) once you login.
+
+Your package is now published and available on atom.io. Head on over to `https://atom.io/packages/your-package-name` to see your package's page.
+
+With `apm publish`, you can bump the version and publish by using
+
+``` command-line
+$ apm publish <version-type>
+```
+
+where `<version-type>` can be `major`, `minor` and `patch`.
+
+The `major` option to the publish command tells apm to increment the first number of the version before publishing so the published version will be `1.0.0` and the Git tag created will be `v1.0.0`.
+
+The `minor` option to the publish command tells apm to increment the second number of the version before publishing so the published version will be `0.1.0` and the Git tag created will be `v0.1.0`.
+
+The `patch` option to the publish command tells apm to increment the third number of the version before publishing so the published version will be `0.0.1` and the Git tag created will be `v0.0.1`.
+
+Use `major` when you make a change that breaks backwards compatibility, like changing defaults or removing features. Use `minor` when adding new functionality or making improvements on existing code. Use `patch` when you fix a bug that was causing incorrect behaviour. Check out [semantic versioning](http://semver.org) to learn more about best practices for versioning your package releases.
+
+You can also run `apm help publish` to see all the available options and `apm help` to see all the other available commands.

--- a/content/hacking-atom/sections/publishing.md
+++ b/content/hacking-atom/sections/publishing.md
@@ -14,7 +14,7 @@ There are a few things you should double check before publishing:
 * Your `package.json` file has a `version` field with a value of `"0.0.0"`.
 * Your `package.json` file has an `engines` field that contains an entry for Atom such as: `"engines": {"atom": ">=1.0.0 <2.0.0"}`.
 * Your package has a `README.md` file at the root.
-* Change the `repository` url in the `package.json` file to match the URL of your repository.
+* Your `repository` URL in the `package.json` file is the same as the URL of your repository.
 * Your package is in a Git repository that has been pushed to [GitHub](https://github.com). Follow [this guide](http://guides.github.com/overviews/desktop) if your package isn't already on GitHub.
 
 #### Publish Your Package

--- a/content/hacking-atom/sections/publishing.md
+++ b/content/hacking-atom/sections/publishing.md
@@ -32,7 +32,7 @@ Now let's review what the `apm publish` command does:
 Now run the following commands to publish your package:
 
 ``` command-line
-$ cd ~/github/my-package
+$ cd path-to-your-package
 $ apm publish minor
 ```
 

--- a/content/hacking-atom/sections/publishing.md
+++ b/content/hacking-atom/sections/publishing.md
@@ -11,7 +11,7 @@ Atom bundles a command line utility called `apm` which we first used back in [Co
 There are a few things you should double check before publishing:
 
 * Your `package.json` file has `name`, `description`, and `repository` fields.
-* Your `package.json` file has a `version` field with a value of  `"0.0.0"`.
+* Your `package.json` file has a `version` field with a value of `"0.0.0"`.
 * Your `package.json` file has an `engines` field that contains an entry for Atom such as: `"engines": {"atom": ">=1.0.0 <2.0.0"}`.
 * Your package has a `README.md` file at the root.
 * Change the `repository` url in the `package.json` file to match the URL of your repository.

--- a/data/toc.yml
+++ b/data/toc.yml
@@ -28,6 +28,7 @@ Chapters:
     - "Package: Word Count"
     - "Package: Modifying Text"
     - Creating a Theme
+    - Publishing
     - Iconography
     - Debugging
     - Writing specs


### PR DESCRIPTION
This PR moves the [Publishing](http://flight-manual.atom.io/hacking-atom/sections/package-word-count/#publishing) section that is part of the Word Count example to its own page.

- Easier to discover for something that people might try to find regularly, not just when creating their first package.
- Less confusing when linking from "Creating a theme".

<img width="233" alt="screen shot 2016-08-05 at 11 22 37 am" src="https://cloud.githubusercontent.com/assets/378023/17432336/f65e7ab2-5afe-11e6-8ccc-c9e514111fab.png">

Closes #247