### PR TITLE
Update editing-and-deleting-text.md

### DIFF
--- a/content/using-atom/sections/editing-and-deleting-text.md
+++ b/content/using-atom/sections/editing-and-deleting-text.md
@@ -29,7 +29,7 @@ You can also delete or cut text out of your buffer with some shortcuts. Be ruthl
 
 * <kbd class="platform-mac platform-windows platform-linux">Ctrl+Shift+K</kbd> - Delete current line
 * <span class="platform-mac"><kbd class="platform-mac">Alt+Backspace</kbd> or <kbd class="platform-mac">Alt+H</kbd></span><kbd class="platform-windows platform-linux">Ctrl+Backspace</kbd> - Delete to beginning of word
-* <span class="platform-mac"><kbd class="platform-mac">Alt+Delete</kbd> or <kbd class="platform-mac">Alt+D</kbd></span><kbd class="platform-windows platform-linux">Ctrl+Delete</kbd> - Delete to beginning of word
+* <span class="platform-mac"><kbd class="platform-mac">Alt+Delete</kbd> or <kbd class="platform-mac">Alt+D</kbd></span><kbd class="platform-windows platform-linux">Ctrl+Delete</kbd> - Delete to end of word
 
 {{#mac}}
 


### PR DESCRIPTION
Change "Ctrl+Delete" description from incorrect "Delete to beginning of word" to correct "Delete to end of word".