### PR TITLE
Added note about Git repository root

### DIFF
--- a/content/using-atom/sections/version-control-in-atom.md
+++ b/content/using-atom/sections/version-control-in-atom.md
@@ -5,6 +5,8 @@ title: Version Control in Atom
 
 Version control is an important aspect of any project and Atom comes with basic [Git](http://git-scm.com) and [GitHub](https://github.com) integration built in.
 
+In order to use version control in Atom, the project root needs to contain the Git repository.
+
 #### Checkout HEAD revision
 
 The <kbd class="platform-mac">Alt+Cmd+Z</kbd><kbd class="platform-windows platform-linux">Alt+Ctrl+Z</kbd> keybinding checks out the `HEAD` revision of the file in the editor.


### PR DESCRIPTION
Until https://github.com/atom/atom/issues/2203 is resolved Git integration only works if the project root contains the repository. This took me a couple of hours to figure out because all the docs seem to say Git integration is built-in and should just work.