### PR TITLE
Include markdown files into search.json

### DIFF
--- a/content/search.json
+++ b/content/search.json
@@ -1,13 +1,13 @@
 {
   "entries": [
-    <% @items.find_all('/*/*/*.asciidoc').reject { |item| item[:exclude_from_search] }.each do |item| %>
+    <% @items.find_all('/*/*/*.{asciidoc,md}').reject { |item| item[:exclude_from_search] }.each do |item| %>
       <% if item[:title] %>
         <% @clean_body = compress(safe_embed(item.compiled_content)) %>
         {
           "title": "<%= safe_embed(item[:title]) %>",
           "category": "",
           "category_url": "",
-          "url": "<%= item[:filename].sub(/^content/, '').sub(/.asciidoc$/, '/') %>",
+          "url": "<%= item[:filename].sub(/^content/, '').sub(/.(asciidoc|md)$/, '/') %>",
           "body": "<%= @clean_body %>",
           "excerpt": "<%= @clean_body[0..140] %>…"
         },


### PR DESCRIPTION
Markdown files are currently left out when building `search.json` resulting in #253.
This adds them again and brings back search functionality.