### PR TITLE
Remove 'all' from list of platform-specific sections

### DIFF
--- a/assets/javascripts/platform-nav.js
+++ b/assets/javascripts/platform-nav.js
@@ -16,7 +16,7 @@
   }
 
   var platformPrefix = 'platform-'
-  var validPlatforms = ['mac', 'windows', 'linux', 'all']
+  var validPlatforms = ['mac', 'windows', 'linux']
 
   var classForPlatform = function (platform) {
     return platformPrefix + platform


### PR DESCRIPTION
Fixes #264 

I tested this and it appears to work in all cases.