### PR TITLE
Update language-scoped settings list

### DIFF
--- a/content/using-atom/sections/basic-customization.md
+++ b/content/using-atom/sections/basic-customization.md
@@ -173,17 +173,18 @@ You can also set several configuration settings differently for different file t
 There are several settings now scoped to an editor's language. Here is the current list:
 
 ```
-editor.tabLength
-editor.softWrap
-editor.softWrapAtPreferredLineLength
+editor.autoIndent
+editor.autoIndentOnPaste
+editor.invisibles
+editor.nonWordCharacters
 editor.preferredLineLength
 editor.scrollPastEnd
-editor.showInvisibles
 editor.showIndentGuide
-editor.nonWordCharacters
-editor.invisibles
-editor.autoIndent
-editor.normalizeIndentOnPaste
+editor.showInvisibles
+editor.softWrap
+editor.softWrapAtPreferredLineLength
+editor.softWrapHangingIndent
+editor.tabLength
 ```
 
 ##### Language-specific Settings in the Settings View


### PR DESCRIPTION
There are currently a few missing settings from this list, and one removed. The current list can be found at https://github.com/atom/settings-view/blob/master/lib/settings-panel.coffee#L17. The removed setting has a PR open here: https://github.com/atom/settings-view/issues/873.

I also put the items in order of appearance in the settings view (alphabetic).
