### PR TITLE
Remove alt-shift-s reference

### DIFF
--- a/content/using-atom/sections/snippets.md
+++ b/content/using-atom/sections/snippets.md
@@ -21,7 +21,7 @@ Many Core and Community packages come bundled with their own snippets that are s
 
 It will also position the cursor in the middle of the `title` tag so you can immediately start filling out the tag. Many snippets have multiple focus points that you can move through with the <kbd class="platform-all">Tab</kbd> key as well - for instance, in the case of this HTML snippet, once you've filled out the title tag you can press <kbd class="platform-all">Tab</kbd> and the cursor will move to the middle of the `body` tag.
 
-To see all the available snippets for the file type that you currently have open, you can type <kbd class="platform-all">Alt+Shift+S</kbd>.
+To see all the available snippets for the file type that you currently have open, choose "Snippets: Available" in the Command Palette.
 
 ![View all available snippets](../../images/snippets.png "View all available snippets")
 

--- a/content/using-atom/sections/writing-in-atom.md
+++ b/content/using-atom/sections/writing-in-atom.md
@@ -47,4 +47,4 @@ If you type `img` and hit `tab` you get a Markdown-formatted image embed code li
 | Item One       | Item Two       |
 ```
 
-Although there are only a handful of Markdown snippets (`b` for bold, `i` for italic, `code` for a code block, etc), they save you from having to look up the more obscure syntaxes. Again, you can easily see a list of all available snippets for the type of file you're currently in by hitting <kbd class="platform-mac platform-windows platform-linux">Alt+Shift+S</kbd>.
+Although there are only a handful of Markdown snippets (`b` for bold, `i` for italic, `code` for a code block, etc), they save you from having to look up the more obscure syntaxes. Again, you can easily see a list of all available snippets for the type of file you're currently in by choosing "Snippets: Available" in the Command Palette.


### PR DESCRIPTION
The default keybinding was removed in atom/snippets.  Ref: atom/snippets@690d4fd