### PR TITLE
mention ATOM_DEV_RESOURCE_PATH when using custom location

### DIFF
--- a/content/behind-atom/sections/developing-node-modules.md
+++ b/content/behind-atom/sections/developing-node-modules.md
@@ -21,6 +21,10 @@ $ apm rebuild
 $ cd <em>WHERE YOU CLONED ATOM</em>
 $ npm link atom-keymap
 
+# If you have cloned Atom in a different location then ~/github/atom
+# you need to set the following environment variable
+$ export ATOM_DEV_RESOURCE_PATH=<em>WHERE YOU CLONED ATOM</em>
+
 # Should work!
 $ atom --dev .
 ```


### PR DESCRIPTION
If the user has cloned Atom in the non-default location this will help to be aware that they have to set an environment variable in order for `atom --dev` work correctly.