### PR TITLE
Remove the beta warning for the tutorial dependent on v1.17

### DIFF
--- a/content/hacking-atom/sections/package-active-editor-info.md
+++ b/content/hacking-atom/sections/package-active-editor-info.md
@@ -3,12 +3,6 @@ title: "Package: Active Editor Info"
 ---
 ### Package: Active Editor Info
 
-{{#warning}}
-
-**Warning:** Some additional features described in this section are not available until Atom v1.17, which is currently in [Beta](https://beta.atom.io).
-
-{{/warning}}
-
 We saw in our [Word Count](/hacking-atom/sections/package-word-count/) package how we could show information in a modal panel. However, panels aren't the only way to extend Atom's UI—you can also add items to the workspace. These items can be dragged to new locations (for example, one of the docks on the edges of the window), and Atom will restore them the next time you open the project. This system is used by Atom's tree view, as well as by third party packages like [Nuclide](http://nuclide.io) for its console, debugger, outline view, and diagnostics (linter results).
 
 For this package, we'll define a workspace item that tells us some information about our active text editor. The final package can be viewed at https://github.com/atom/active-editor-info.


### PR DESCRIPTION
🚨 **Do not merge until v1.17 reaches the Stable channel.** 🚨 

Removes the beta warning block from the tutorial added in #332.