### PR TITLE
Update installing-atom.md

### DIFF
--- a/content/getting-started/sections/installing-atom.md
+++ b/content/getting-started/sections/installing-atom.md
@@ -184,3 +184,12 @@ $ apm config set https-proxy <em>YOUR_PROXY_ADDRESS</em>
 ```
 
 You can run `apm config get https-proxy` to verify it has been set correctly.
+
+##### Behind a corporate proxy and can't get through after setting both https-proxy and http-proxy with your credentials?
+
+Set both https-proxy and http-proxy to the same (for instance, http//user:password@proxy.corp.com:8080).
+
+``` command-line
+$ apm config set https-proxy <em>YOUR_PROXY_ADDRESS</em>
+$ apm config set http-proxy <em>YOUR_PROXY_ADDRESS</em>
+```


### PR DESCRIPTION
Config settings for Windows 7 in a corporate environment.

After several hours and many failed attempts, it was the above proposal that worked for our team.

Setting both HTTP-PROXY and HTTPS-PROXY to the same value allowed Atom to access the internet.