### PR TITLE
Update find-and-replace.md

### DIFF
--- a/content/using-atom/sections/find-and-replace.md
+++ b/content/using-atom/sections/find-and-replace.md
@@ -12,7 +12,7 @@ If you launch either of those commands, you'll be greeted with the Find and Repl
 
 ![Find and replace text in the current file](../../images/find-replace-file.png "Find and replace text in the current file")
 
-To search within your current file you can press <kbd class="platform-mac">Cmd+F</kbd><kbd class="platform-windows platform-linux">Ctrl+F</kbd>, type in a search string and press <kbd class="platform-all">Enter</kbd> (or <kbd class="platform-mac">Cmd+G</kbd><kbd class="platform-windows platform-linux">F3</kbd> or the "Find Next" button) multiple times to cycle through all the matches in that file. The Find and Replace panel also contains buttons for toggling case sensitivity, performing regular expression matching and scoping the search to selections.
+To search within your current file you can press <kbd class="platform-mac">Cmd+F</kbd><kbd class="platform-windows platform-linux">Ctrl+F</kbd>, type in a search string and press <kbd class="platform-all">Enter</kbd> (or <kbd class="platform-mac">Cmd+G</kbd><kbd class="platform-windows platform-linux">F3</kbd> or the "Find Next" button) multiple times to cycle through all the matches in that file. The Find and Replace panel also contains buttons for toggling case sensitivity, performing regular expression matching and scoping the search to selections. Note: In the replacement part of a regex the syntax $1, $2, … $& must be used.
 
 If you type a string in the replacement text box, you can replace matches with a different string. For example, if you wanted to replace every instance of the string "Scott" with the string "Dragon", you would enter those values in the two text boxes and press the "Replace All" button to perform the replacements.
 

--- a/content/using-atom/sections/find-and-replace.md
+++ b/content/using-atom/sections/find-and-replace.md
@@ -12,9 +12,15 @@ If you launch either of those commands, you'll be greeted with the Find and Repl
 
 ![Find and replace text in the current file](../../images/find-replace-file.png "Find and replace text in the current file")
 
-To search within your current file you can press <kbd class="platform-mac">Cmd+F</kbd><kbd class="platform-windows platform-linux">Ctrl+F</kbd>, type in a search string and press <kbd class="platform-all">Enter</kbd> (or <kbd class="platform-mac">Cmd+G</kbd><kbd class="platform-windows platform-linux">F3</kbd> or the "Find Next" button) multiple times to cycle through all the matches in that file. The Find and Replace panel also contains buttons for toggling case sensitivity, performing regular expression matching and scoping the search to selections. Note: In the replacement part of a regex the syntax $1, $2, … $& must be used.
+To search within your current file you can press <kbd class="platform-mac">Cmd+F</kbd><kbd class="platform-windows platform-linux">Ctrl+F</kbd>, type in a search string and press <kbd class="platform-all">Enter</kbd> (or <kbd class="platform-mac">Cmd+G</kbd><kbd class="platform-windows platform-linux">F3</kbd> or the "Find Next" button) multiple times to cycle through all the matches in that file. The Find and Replace panel also contains buttons for toggling case sensitivity, performing regular expression matching and scoping the search to selections. 
 
 If you type a string in the replacement text box, you can replace matches with a different string. For example, if you wanted to replace every instance of the string "Scott" with the string "Dragon", you would enter those values in the two text boxes and press the "Replace All" button to perform the replacements.
+
+{{#note}}
+
+**Note:** With a regular expression search, the replacement syntax to refer back to search groups is  $1, $2, … $& 
+
+{{/note}}
 
 You can also find and replace throughout your entire project if you invoke the panel with <kbd class="platform-mac">Cmd+Shift+F</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+F</kbd>.
 


### PR DESCRIPTION
Proposed adding this note at the end of line 15:
"Note: In the replacement part of a regex the syntax $1, $2, … $& must be used."
My "regex" experience is with languages that use the \1, \2 syntax, so the need to use Javascript syntax was not obvious to me.
Regards.