### PR TITLE
Fixed a typo in package-word-count.md

### DIFF
--- a/content/hacking-atom/sections/package-word-count.md
+++ b/content/hacking-atom/sections/package-word-count.md
@@ -345,7 +345,7 @@ toggle: ->
     @modalPanel.show()
 ```
 
-This should be fairly simple to understand. We're looking to see if the modal element is visible and hiding or showing it depending on it's current state.
+This should be fairly simple to understand. We're looking to see if the modal element is visible and hiding or showing it depending on its current state.
 
 ##### The Flow
 


### PR DESCRIPTION
Let's use the apostrophe correctly in the manual.