### PR TITLE
Fix Toggle Developer Tools macOS key combination

### DIFF
--- a/content/hacking-atom/sections/debugging.md
+++ b/content/hacking-atom/sections/debugging.md
@@ -188,7 +188,7 @@ If you notice that a package's keybindings are taking precedence over core Atom 
 
 #### Check Font Rendering Issues
 
-You can determine which fonts are being used to render a specific piece of text by using the Developer Tools. To open the Developer Tools press <kbd class="platform-mac">Alt+Shift+I</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+I</kbd>. Once the Developer Tools are open, click the "Elements" tab. Use the [standard tools for finding the element](https://developers.google.com/web/tools/chrome-devtools/inspect-styles/) containing the text you want to check. Once you have selected the element, you can click the "Computed" tab in the styles pane and scroll to the bottom. The list of fonts being used will be shown there:
+You can determine which fonts are being used to render a specific piece of text by using the Developer Tools. To open the Developer Tools press <kbd class="platform-mac">Alt+Cmd+I</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+I</kbd>. Once the Developer Tools are open, click the "Elements" tab. Use the [standard tools for finding the element](https://developers.google.com/web/tools/chrome-devtools/inspect-styles/) containing the text you want to check. Once you have selected the element, you can click the "Computed" tab in the styles pane and scroll to the bottom. The list of fonts being used will be shown there:
 
 ![Fonts In Use](../../images/fonts-in-use.png "Fonts In Use")
 

--- a/content/hacking-atom/sections/debugging.md
+++ b/content/hacking-atom/sections/debugging.md
@@ -188,7 +188,7 @@ If you notice that a package's keybindings are taking precedence over core Atom 
 
 #### Check Font Rendering Issues
 
-You can determine which fonts are being used to render a specific piece of text by using the Developer Tools. To open the Developer Tools press <kbd class="platform-mac">Cmd+Shift+I</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+I</kbd>. Once the Developer Tools are open, click the "Elements" tab. Use the [standard tools for finding the element](https://developers.google.com/web/tools/chrome-devtools/inspect-styles/) containing the text you want to check. Once you have selected the element, you can click the "Computed" tab in the styles pane and scroll to the bottom. The list of fonts being used will be shown there:
+You can determine which fonts are being used to render a specific piece of text by using the Developer Tools. To open the Developer Tools press <kbd class="platform-mac">Alt+Shift+I</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+I</kbd>. Once the Developer Tools are open, click the "Elements" tab. Use the [standard tools for finding the element](https://developers.google.com/web/tools/chrome-devtools/inspect-styles/) containing the text you want to check. Once you have selected the element, you can click the "Computed" tab in the styles pane and scroll to the bottom. The list of fonts being used will be shown there:
 
 ![Fonts In Use](../../images/fonts-in-use.png "Fonts In Use")
 


### PR DESCRIPTION
The macOS key combination described in the flight manual is Cmd+Shift+I. However, the default is Alt+Cmd+I.