### PR TITLE
Clarified backspace and arrow key issues with components and input field

### DIFF
--- a/content/behind-atom/sections/keymaps-in-depth.md
+++ b/content/behind-atom/sections/keymaps-in-depth.md
@@ -170,7 +170,13 @@ But if you click inside the Tree View and press <kbd class='platform-mac'>Cmd+O<
 
 #### Forcing Chromium's Native Keystroke Handling
 
-If you want to force the native browser behavior for a given keystroke, use the `native!` directive as the command of a binding. This can be useful to enable the correct behavior in native input elements, for example. If you apply the `.native-key-bindings` class to an element, all the keystrokes typically handled by the browser will be assigned the `native!` directive.
+If you want to force the native browser behavior for a given keystroke, use the `native!` directive as the command of a binding. This can be useful to enable the correct behavior in native input elements.  If you apply the `.native-key-bindings` class to an element, all the keystrokes typically handled by the browser will be assigned the `native!` directive.
+
+{{#tip}}
+
+**Tip:** Components and input elements may not correctly handle backspace and arrow keys without forcing this behavior.  If your backspace isn't working correctly inside of a component, add either the directive or the `.native-key-bindings` class.
+
+{{/tip}}
 
 #### Overloading Key Bindings
 


### PR DESCRIPTION
Even after reading the original Flight Manual section, "Forcing Chromium's Native Keystroke Handling", I didn't make the connection that a bug with not being able to use backspace or arrow keys inside an included component (which has an input field) was related.   Clarified this in a tip.