### PR TITLE
Fix the steps for developing node modules

### DIFF
--- a/content/behind-atom/sections/developing-node-modules.md
+++ b/content/behind-atom/sections/developing-node-modules.md
@@ -14,11 +14,11 @@ $ git clone https://github.com/atom/atom-keymap.git
 $ cd atom-keymap
 $ npm install
 $ npm link
+$ cd <em>WHERE YOU CLONED ATOM</em>
 
 # This is the special step, it makes the Node module work with Atom's version of Node
 $ apm rebuild
 
-$ cd <em>WHERE YOU CLONED ATOM</em>
 $ npm link atom-keymap
 
 # If you have cloned Atom in a different location than <span class="platform-mac platform-linux">~/github/atom</span><span class="platform-windows">%USERPROFILE%\github\atom</span>

--- a/content/behind-atom/sections/developing-node-modules.md
+++ b/content/behind-atom/sections/developing-node-modules.md
@@ -15,11 +15,10 @@ $ cd atom-keymap
 $ npm install
 $ npm link
 $ cd <em>WHERE YOU CLONED ATOM</em>
+$ npm link atom-keymap
 
 # This is the special step, it makes the Node module work with Atom's version of Node
 $ apm rebuild
-
-$ npm link atom-keymap
 
 # If you have cloned Atom in a different location than <span class="platform-mac platform-linux">~/github/atom</span><span class="platform-windows">%USERPROFILE%\github\atom</span>
 # you need to set the following environment variable


### PR DESCRIPTION
Some node modules, for example `atom-keymap`, `keyboard-layout` and `node-pathwatcher` requires `apm rebuild` to be run in the Atom directory on Windows. This PR changes the steps so `apm rebuild` is always run from the Atom directory.

/cc: @50Wliu 