### PR TITLE
Fix CI failure: "301 Peer certificate cannot be authenticated"

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,10 @@ task :run_proofer do
 
   # Ignore platform switcher hash URLs
   platform_hash_urls = ['#platform-mac', '#platform-windows', '#platform-linux', '#platform-all']
-  HTMLProofer.check_directory("./output", {:url_ignore => platform_hash_urls}).run
+  HTMLProofer.check_directory("./output", {
+    :url_ignore => platform_hash_urls,
+    :typhoeus => { :ssl_verifypeer => false }
+  }).run
 end
 
 # Detects instances of Issue #204


### PR DESCRIPTION
Prior to this change, the build was [failing](https://travis-ci.org/atom/flight-manual.atom.io/builds/265717625#L332) as follows:

```
- ./output/upgrading-to-1-0-apis/sections/upgrading-your-syntax-theme/index.html
  *  External link http://www.html5rocks.com/en/tutorials/webcomponents/shadowdom-201#toc-style-host failed: 301 Peer certificate cannot be authenticated with given CA certificates
- ./output/upgrading-to-1-0-apis/sections/upgrading-your-ui-theme-or-package-selectors/index.html
  *  External link http://www.html5rocks.com/en/tutorials/webcomponents/shadowdom failed: 301 Peer certificate cannot be authenticated with given CA certificates
  *  External link http://www.html5rocks.com/en/tutorials/webcomponents/shadowdom-201#toc-style-cat-hat failed: 301 Peer certificate cannot be authenticated with given CA certificates
rake aborted!
HTML-Proofer found 3 failures!
```

Some other folks have run into similar issues with Travis CI and html-proofer (https://github.com/gjtorikian/html-proofer/issues/140), and tweaking the typhoeus options seems to be the fix people are using (https://github.com/gjtorikian/html-proofer/issues/140#issuecomment-69042038).

With this change in place, we get a nice green build: https://travis-ci.org/atom/flight-manual.atom.io/builds/265746208 ✅
