### PR TITLE
Fix Travis CI failures related to SSL certificate issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,7 @@ git:
 script:
   - npm install
   - script/cibuild
+addons:
+  apt:
+    packages:
+      - libcurl3-dev


### PR DESCRIPTION
Prior to this change, the [CI build was suffering](https://travis-ci.org/atom/flight-manual.atom.io/builds/277092727) from the following 2 failures:

```
- ./output/hacking-atom/sections/package-active-editor-info/index.html
  *  External link https://nuclide.io failed: response code 0 means something's wrong.
             It's possible libcurl couldn't connect to the server or perhaps the request timed out.
             Sometimes, making too many requests at once also breaks things.
             Either way, the return message (if any) from the server is: SSL connect error
- ./output/using-atom/sections/moving-in-atom/index.html
  *  External link https://ctags.io failed: response code 0 means something's wrong.
             It's possible libcurl couldn't connect to the server or perhaps the request timed out.
             Sometimes, making too many requests at once also breaks things.
             Either way, the return message (if any) from the server is: SSL connect error
rake aborted!
HTML-Proofer found 2 failures!
```

With the changes in this pull request, we're [back to green](https://travis-ci.org/atom/flight-manual.atom.io/builds/278364342)! :green_apple:😅

---

Shout out to https://github.com/atomist/end-user-documentation/commit/8d86ff294f8d68002432fae85d30b26806748dba for the fix. :zap:

xref: https://github.com/gjtorikian/html-proofer/issues/376
