### PR TITLE
Whenever "open source" is used as an adjective before a noun, it shou…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,7 @@ These use the same format as [Admonition blocks](#admonition-blocks), but apply 
 * **DO NOT** use Latin contractions such as "i.e.", "e.g.", "c.f.", among others
 * **DO** use the English equivalent: "i.e." &rarr; "in other words", "e.g." &rarr; "for example", "c.f." &rarr; hyperlink to the thing you're referring to
 * **DO** use [title-case](http://titlecase.com) for *all* headings
+* **DO** hyphenate the words "open" and "source" when they act as an adjective before the noun. For example, "Open-source software is great."
 
 ### Images
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ These use the same format as [Admonition blocks](#admonition-blocks), but apply 
 * **DO NOT** use Latin contractions such as "i.e.", "e.g.", "c.f.", among others
 * **DO** use the English equivalent: "i.e." &rarr; "in other words", "e.g." &rarr; "for example", "c.f." &rarr; hyperlink to the thing you're referring to
 * **DO** use [title-case](http://titlecase.com) for *all* headings
-* **DO** hyphenate the words "open" and "source" when they act as an adjective before the noun. For example, "Open-source software is great."
+* **DO** hyphenate the words "open" and "source" when they act as an adjective before the noun they describe
 
 ### Images
 

--- a/assets/vendor/lunr.js/example/example_data.json
+++ b/assets/vendor/lunr.js/example/example_data.json
@@ -2659,7 +2659,7 @@
       "score": 0,
       "community_owned": false,
       "title": "Facebook style autocomplete using dojo needed.",
-      "body": "<p>I found facebook style autocomplete using jQuery. But im using dojo framework for my web app. Can you suggest how to implement or any open source code available for autocomplete using dojo framework. ?</p>\n\n<p>Using jquery :</p>\n\n<p><a href=\"http://devthought.com/wp-content/articles/autocompletelist/test.html\" rel=\"nofollow\">http://devthought.com/wp-content/articles/autocompletelist/test.html</a></p>\n"
+      "body": "<p>I found facebook style autocomplete using jQuery. But im using dojo framework for my web app. Can you suggest how to implement or any open-source code available for autocomplete using dojo framework. ?</p>\n\n<p>Using jquery :</p>\n\n<p><a href=\"http://devthought.com/wp-content/articles/autocompletelist/test.html\" rel=\"nofollow\">http://devthought.com/wp-content/articles/autocompletelist/test.html</a></p>\n"
     },
     {
       "tags": [

--- a/content/getting-started/sections/why-atom.md
+++ b/content/getting-started/sections/why-atom.md
@@ -39,7 +39,7 @@ For example, the layout of our workspace and panes is based on flexbox. It's an 
 
 With the entire industry pushing web technology forward, we're confident that we're building Atom on fertile ground. Native UI technologies come and go, but the web is a standard that becomes more capable and ubiquitous with every passing year. We're excited to dig deeper into its toolbox.
 
-#### An Open Source Text Editor
+#### An Open-Source Text Editor
 
 We see Atom as a perfect complement to GitHub's primary mission of building better software by working together. Atom is a long-term investment, and GitHub will continue to support its development with a dedicated team going forward. But we also know that we can't achieve our vision for Atom alone. As Emacs and Vim have demonstrated over the past three decades, if you want to build a thriving, long-lasting community around a text editor, it has to be open source.
 


### PR DESCRIPTION
…ld be hyphenated.

https://www.englishforums.com/English/OpenSourceOrOpenSource/bzpcd/post.htm

All other instances of "open source" are adjectives after the noun, and don't require a hyphen.