### PR TITLE
Link to GitHub Help instead of broken Desktop guide link

### DIFF
--- a/content/hacking-atom/sections/publishing.md
+++ b/content/hacking-atom/sections/publishing.md
@@ -15,7 +15,7 @@ There are a few things you should double check before publishing:
 * Your `package.json` file has an `engines` field that contains an entry for Atom such as: `"engines": {"atom": ">=1.0.0 <2.0.0"}`.
 * Your package has a `README.md` file at the root.
 * Your `repository` URL in the `package.json` file is the same as the URL of your repository.
-* Your package is in a Git repository that has been pushed to [GitHub](https://github.com). Follow [this guide](http://guides.github.com/overviews/desktop) if your package isn't already on GitHub.
+* Your package is in a Git repository that has been pushed to [GitHub](https://github.com). Follow [this guide](https://help.github.com/articles/importing-a-git-repository-using-the-command-line/) if your package isn't already on GitHub.
 
 #### Publish Your Package
 


### PR DESCRIPTION
This should fix the build errors occurring.