### PR TITLE
Update contributing-to-official-atom-packages.md

### DIFF
--- a/content/hacking-atom/sections/contributing-to-official-atom-packages.md
+++ b/content/hacking-atom/sections/contributing-to-official-atom-packages.md
@@ -9,7 +9,7 @@ If you think you know which package is causing the issue you are reporting, feel
 
 ##### Cloning
 
-The first step is creating your own clone. For some packages, such as [atom/tree-view](https://github.com/atom/tree-view), you may need to install the [requirements necessary for building Atom](http://flight-manual.atom.io/hacking-atom/sections/hacking-on-atom-core/#building) in order to run `apm install`.
+The first step is creating your own clone. For some packages, you may need to install the [requirements necessary for building Atom](http://flight-manual.atom.io/hacking-atom/sections/hacking-on-atom-core/#building) in order to run `apm install`.
 
 For example, if you want to make changes to the `tree-view` package, fork the repo on your github account, then clone it:
 

--- a/content/hacking-atom/sections/contributing-to-official-atom-packages.md
+++ b/content/hacking-atom/sections/contributing-to-official-atom-packages.md
@@ -9,7 +9,7 @@ If you think you know which package is causing the issue you are reporting, feel
 
 ##### Cloning
 
-The first step is creating your own clone.
+The first step is creating your own clone. For some packages, such as [atom/tree-view](https://github.com/atom/tree-view), you may need to install the [requirements necessary for building Atom](http://flight-manual.atom.io/hacking-atom/sections/hacking-on-atom-core/#building) in order to run `apm install`.
 
 For example, if you want to make changes to the `tree-view` package, fork the repo on your github account, then clone it:
 

--- a/content/hacking-atom/sections/contributing-to-official-atom-packages.md
+++ b/content/hacking-atom/sections/contributing-to-official-atom-packages.md
@@ -9,7 +9,7 @@ If you think you know which package is causing the issue you are reporting, feel
 
 ##### Cloning
 
-The first step is creating your own clone. For some packages, you may need to install the [requirements necessary for building Atom](http://flight-manual.atom.io/hacking-atom/sections/hacking-on-atom-core/#building) in order to run `apm install`.
+The first step is creating your own clone. For some packages, you may also need to install the [requirements necessary for building Atom](http://flight-manual.atom.io/hacking-atom/sections/hacking-on-atom-core/#building) in order to run `apm install`.
 
 For example, if you want to make changes to the `tree-view` package, fork the repo on your github account, then clone it:
 


### PR DESCRIPTION
This follows from #369 where the link used the wrong markdown syntax and clarification was needed that building Atom is not always required. Should be good to merge now.