### PR TITLE
Force TravisCI to use Node.js 7 to avoid node-sass compatibility error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ cache:
 sudo: false
 git:
   depth: 10
+before_install:
+  - nvm install 7
+  - nvm use 7
 script:
   - npm install
   - script/cibuild

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/atom/docs.git"
   },
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">=4.0.0 <8.0.0"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.6.0",


### PR DESCRIPTION
This change forces TravisCI to use Node.js 7 instead of the system-wide
install (Node.js 9) to avoid version compatibility issues with the
node-sass package.  node-sass has builds against specific Node.js versions
and can't be used with anything newer than Node.js 7 unless we upgrade
our node-sass dependency.