### PR TITLE
Add windows-build-tools to build instructions for Windows

### DIFF
--- a/content/hacking-atom/sections/hacking-on-atom-core.md
+++ b/content/hacking-atom/sections/hacking-on-atom-core.md
@@ -68,10 +68,11 @@ In order to build Atom from source, you need to have a number of other requireme
   * The `python.exe` must be available at `%SystemDrive%\Python27\python.exe`. If it is installed elsewhere create a symbolic link to the directory containing the `python.exe` using: `mklink /d %SystemDrive%\Python27 D:\elsewhere\Python27`
 * 7zip (7z.exe available from the command line) - for creating distribution zip files
 * C++ build tools, either:
-  * [windows-build-tools](https://www.npmjs.com/package/windows-build-tools) (Also installs Python 2.7.x)
   * [Visual C++ Build Tools 2015](https://landinghub.visualstudio.com/visual-cpp-build-tools)
   * [Visual Studio 2013 Update 5](https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs) (Express Edition or better)
   * [Visual Studio 2015](https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs) (Community Edition or better)
+  * **Unsupported** but more convenient for some who know Node: [windows-build-tools](https://www.npmjs.com/package/windows-build-tools)
+
 
   Also ensure that:
 

--- a/content/hacking-atom/sections/hacking-on-atom-core.md
+++ b/content/hacking-atom/sections/hacking-on-atom-core.md
@@ -67,7 +67,8 @@ In order to build Atom from source, you need to have a number of other requireme
 * Python v2.7.x
   * The `python.exe` must be available at `%SystemDrive%\Python27\python.exe`. If it is installed elsewhere create a symbolic link to the directory containing the `python.exe` using: `mklink /d %SystemDrive%\Python27 D:\elsewhere\Python27`
 * 7zip (7z.exe available from the command line) - for creating distribution zip files
-* Visual Studio, either:
+* C++ build tools, either:
+  * [windows-build-tools](https://www.npmjs.com/package/windows-build-tools) (Also installs Python 2.7.x)
   * [Visual C++ Build Tools 2015](http://landinghub.visualstudio.com/visual-cpp-build-tools)
   * [Visual Studio 2013 Update 5](https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs) (Express Edition or better)
   * [Visual Studio 2015](https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs) (Community Edition or better)


### PR DESCRIPTION
As I suggested in https://github.com/atom/atom/issues/15368, this adds [windows-build-tools](https://www.npmjs.com/package/windows-build-tools) to the build requirements as an option for Visual Studio. That title is also changed to C++ build tools, as it no longer only lists products directly related to Visual Studio.