### PR TITLE
Add new sections to discuss commands that have no keyboard shortcut by default

### DIFF
--- a/content/using-atom/sections/moving-in-atom.md
+++ b/content/using-atom/sections/moving-in-atom.md
@@ -43,9 +43,10 @@ You can also move directly to a specific line (and column) number with <kbd clas
 
 #### Additional Movement and Selection Commands
 
-Atom also has a few movement and selection commands that don't have keybindings by default.   You can access these commands from the [Command Palette](http://flight-manual.atom.io/getting-started/sections/atom-basics/#command-palette), but if you find yourself using commands that don't have a keybinding often, have no fear!  You can easily add an entry to your `keymaps.cson` to create a key combination.  
+Atom also has a few movement and selection commands that don't have keybindings by default.   You can access these commands from the [Command Palette](/getting-started/sections/atom-basics/#command-palette), but if you find yourself using commands that don't have a keybinding often, have no fear!  You can easily add an entry to your `keymap.cson` to create a key combination.  You can open `keymap.cson` file in an editor from the Atom > Keymap menu.
 
-For example,  the command `editor:move-to-beginning-of-screen-line` is available in the command palette, but it's not bound to any keyboard shortcut.  To create a keyboard shortcut you need to add a entry in your `keymaps.cson` file.   For `editor:select-to-previous-word-boundary`, you can add the following to your `keymaps.cson`:
+For example,  the command `editor:move-to-beginning-of-screen-line` is available in the command palette, but it's not bound to any key combination.  To create a key combination you need to add an entry in your `keymap.cson` file.    For `editor:select-to-previous-word-boundary`, you can add the following to your `keymap.cson`:
+
 
 {{#mac}}
 ```coffee
@@ -68,7 +69,7 @@ For example,  the command `editor:move-to-beginning-of-screen-line` is available
 ```
 {{/linux}}
 
-This will bind the command `editor:select-to-previous-word-boundary` to <kbd class="platform-mac">Cmd+Shift+E</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+E</kbd>.  For more information on customizing your keybindings, see [Customizing Keybindings](http://flight-manual.atom.io/using-atom/sections/basic-customization/#customizing-keybindings).
+This will bind the command `editor:select-to-previous-word-boundary` to <kbd class="platform-mac">Cmd+Shift+E</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+E</kbd>.  For more information on customizing your keybindings, see [Customizing Keybindings](/using-atom/sections/basic-customization/#customizing-keybindings).
 
 Here's a list of Movement and Selection Commands that have a keyboard shortcut by default:
 

--- a/content/using-atom/sections/moving-in-atom.md
+++ b/content/using-atom/sections/moving-in-atom.md
@@ -40,6 +40,108 @@ You can also move directly to a specific line (and column) number with <kbd clas
 
 ![Go directly to a line](../../images/goto.png "Go directly to a line")
 
+
+#### Additional Movement and Selection Commands
+
+Atom also has a few movement commands that aren't binded to any keyboard shortcut.   You can access these commands from the [Command Palatte](http://flight-manual.atom.io/getting-started/sections/atom-basics/#command-palette), but if you find yourself using a commands that doesn't have a keyboard shortcut often, have no fear!  You can easily add a entry to your `keymaps.cson` to create a keyboard shortcut.  For example,  the command `editor:move-to-beginning-of-screen-line` is available in the command palette, but not binded to any keyboard shortcut.  If you would like this to have a keyboard shortcut, you can add a entry in your `keymaps.cson` file.   For `editor:select-to-previous-word-boundary`, you can add the following to your `keymaps.cson`:
+{{#mac}}
+```coffee
+'atom-text-editor':
+  'cmd-shift-e': 'editor:select-to-previous-word-boundary'
+```
+{{/mac}}
+
+{{#windows}}
+```coffee
+'atom-text-editor':
+  'ctrl-shift-e': 'editor:select-to-previous-word-boundary'
+```
+{{/windows}}
+
+{{#linux}}
+```coffee
+'atom-text-editor':
+  'ctrl-shift-e': 'editor:select-to-previous-word-boundary'
+```
+{{/linux}}
+
+This will bind the command `editor:select-to-previous-word-boundary` to <kbd class="platform-mac">Cmd+Shift+E</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+E</kbd>.  For more information on customizing keyboard shortcuts, see [Customizing Keybindings](http://flight-manual.atom.io/using-atom/sections/basic-customization/#customizing-keybindings).
+
+Here's a list of Movement and Selection Commands that have a keyboard shortcut by default:
+
+{{#mac}}
+
+```
+
+editor:move-to-beginning-of-next-paragraph
+editor:move-to-beginning-of-previous-paragraph
+editor:move-to-beginning-of-screen-line
+editor:move-to-beginning-of-line
+editor:move-to-beginning-of-next-word
+editor:move-to-previous-word-boundary
+editor:move-to-next-word-boundary
+editor:move-to-previous-subword-boundary
+editor:select-to-beginning-of-previous-paragraph
+editor:select-to-end-of-line
+editor:select-to-beginning-of-line
+editor:select-to-beginning-of-word
+editor:select-to-beginning-of-next-word
+editor:select-to-next-word-boundary
+editor:select-to-previous-word-boundary
+
+```
+
+{{/mac}}
+{{#windows}}
+```
+
+editor:move-to-beginning-of-next-paragraph
+editor:move-to-beginning-of-previous-paragraph
+editor:move-to-beginning-of-screen-line
+editor:move-to-beginning-of-line
+editor:move-to-end-of-line
+editor:move-to-first-character-of-line
+editor:move-to-beginning-of-next-word
+editor:move-to-previous-word-boundary
+editor:move-to-next-word-boundary
+editor:select-to-beginning-of-next-paragraph
+editor:select-to-beginning-of-previous-paragraph
+editor:select-to-end-of-line
+editor:select-to-beginning-of-line
+editor:select-to-beginning-of-word
+editor:select-to-beginning-of-next-word
+editor:select-to-next-word-boundary
+editor:select-to-previous-word-boundary
+
+```
+
+{{/windows}}
+{{#linux}}
+```
+
+editor:move-to-beginning-of-next-paragraph
+editor:move-to-beginning-of-previous-paragraph
+editor:move-to-beginning-of-screen-line
+editor:move-to-beginning-of-line
+editor:move-to-end-of-line
+editor:move-to-first-character-of-line
+editor:move-to-beginning-of-next-word
+editor:move-to-previous-word-boundary
+editor:move-to-next-word-boundary
+editor:select-to-beginning-of-next-paragraph
+editor:select-to-beginning-of-previous-paragraph
+editor:select-to-end-of-line
+editor:select-to-beginning-of-line
+editor:select-to-beginning-of-word
+editor:select-to-beginning-of-next-word
+editor:select-to-next-word-boundary
+editor:select-to-previous-word-boundary
+
+```
+
+{{/linux}}
+
+
 #### Navigating by Symbols
 
 You can also jump around a little more informatively with the Symbols View. To jump to a symbol such as a method definition, press <kbd class="platform-mac">Cmd+R</kbd><kbd class="platform-windows platform-linux">Ctrl+R</kbd>. This opens a list of all symbols in the current file, which you can fuzzy filter similarly to <kbd class="platform-mac">Cmd+T</kbd><kbd class="platform-windows platform-linux">Ctrl+T</kbd>. You can also search for symbols across your project but it requires a `tags` file.

--- a/content/using-atom/sections/moving-in-atom.md
+++ b/content/using-atom/sections/moving-in-atom.md
@@ -43,9 +43,9 @@ You can also move directly to a specific line (and column) number with <kbd clas
 
 #### Additional Movement and Selection Commands
 
-Atom also has a few movement and selection commands that don't have a keyboard shortcut mapped to it.   You can access these commands from the [Command Palatte](http://flight-manual.atom.io/getting-started/sections/atom-basics/#command-palette), but if you find yourself using a command that doesn't have a keyboard shortcut often, have no fear!  You can easily add a entry to your `keymaps.cson` to create a keyboard shortcut.  
+Atom also has a few movement and selection commands that don't have keybindings by default.   You can access these commands from the [Command Palette](http://flight-manual.atom.io/getting-started/sections/atom-basics/#command-palette), but if you find yourself using commands that don't have a keybinding often, have no fear!  You can easily add an entry to your `keymaps.cson` to create a key combination.  
 
-For example,  the command `editor:move-to-beginning-of-screen-line` is available in the command palette, but it's not binded to any keyboard shortcut.  To add create a keyboard shortcut you need to add a entry in your `keymaps.cson` file.   For `editor:select-to-previous-word-boundary`, you can add the following to your `keymaps.cson`:
+For example,  the command `editor:move-to-beginning-of-screen-line` is available in the command palette, but it's not bound to any keyboard shortcut.  To create a keyboard shortcut you need to add a entry in your `keymaps.cson` file.   For `editor:select-to-previous-word-boundary`, you can add the following to your `keymaps.cson`:
 
 {{#mac}}
 ```coffee
@@ -68,14 +68,13 @@ For example,  the command `editor:move-to-beginning-of-screen-line` is available
 ```
 {{/linux}}
 
-This will bind the command `editor:select-to-previous-word-boundary` to <kbd class="platform-mac">Cmd+Shift+E</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+E</kbd>.  For more information on customizing keyboard shortcuts, see [Customizing Keybindings](http://flight-manual.atom.io/using-atom/sections/basic-customization/#customizing-keybindings).
+This will bind the command `editor:select-to-previous-word-boundary` to <kbd class="platform-mac">Cmd+Shift+E</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+E</kbd>.  For more information on customizing your keybindings, see [Customizing Keybindings](http://flight-manual.atom.io/using-atom/sections/basic-customization/#customizing-keybindings).
 
 Here's a list of Movement and Selection Commands that have a keyboard shortcut by default:
 
 {{#mac}}
 
 ```
-
 editor:move-to-beginning-of-next-paragraph
 editor:move-to-beginning-of-previous-paragraph
 editor:move-to-beginning-of-screen-line
@@ -91,13 +90,12 @@ editor:select-to-beginning-of-word
 editor:select-to-beginning-of-next-word
 editor:select-to-next-word-boundary
 editor:select-to-previous-word-boundary
-
 ```
 
 {{/mac}}
+
 {{#windows}}
 ```
-
 editor:move-to-beginning-of-next-paragraph
 editor:move-to-beginning-of-previous-paragraph
 editor:move-to-beginning-of-screen-line
@@ -115,13 +113,12 @@ editor:select-to-beginning-of-word
 editor:select-to-beginning-of-next-word
 editor:select-to-next-word-boundary
 editor:select-to-previous-word-boundary
-
 ```
 
 {{/windows}}
+
 {{#linux}}
 ```
-
 editor:move-to-beginning-of-next-paragraph
 editor:move-to-beginning-of-previous-paragraph
 editor:move-to-beginning-of-screen-line
@@ -139,7 +136,6 @@ editor:select-to-beginning-of-word
 editor:select-to-beginning-of-next-word
 editor:select-to-next-word-boundary
 editor:select-to-previous-word-boundary
-
 ```
 
 {{/linux}}

--- a/content/using-atom/sections/moving-in-atom.md
+++ b/content/using-atom/sections/moving-in-atom.md
@@ -44,6 +44,7 @@ You can also move directly to a specific line (and column) number with <kbd clas
 #### Additional Movement and Selection Commands
 
 Atom also has a few movement commands that aren't binded to any keyboard shortcut.   You can access these commands from the [Command Palatte](http://flight-manual.atom.io/getting-started/sections/atom-basics/#command-palette), but if you find yourself using a commands that doesn't have a keyboard shortcut often, have no fear!  You can easily add a entry to your `keymaps.cson` to create a keyboard shortcut.  For example,  the command `editor:move-to-beginning-of-screen-line` is available in the command palette, but not binded to any keyboard shortcut.  If you would like this to have a keyboard shortcut, you can add a entry in your `keymaps.cson` file.   For `editor:select-to-previous-word-boundary`, you can add the following to your `keymaps.cson`:
+
 {{#mac}}
 ```coffee
 'atom-text-editor':

--- a/content/using-atom/sections/moving-in-atom.md
+++ b/content/using-atom/sections/moving-in-atom.md
@@ -43,9 +43,9 @@ You can also move directly to a specific line (and column) number with <kbd clas
 
 #### Additional Movement and Selection Commands
 
-Atom also has a few movement and selection commands that don't have keybindings by default.   You can access these commands from the [Command Palette](/getting-started/sections/atom-basics/#command-palette), but if you find yourself using commands that don't have a keybinding often, have no fear!  You can easily add an entry to your `keymap.cson` to create a key combination.  You can open `keymap.cson` file in an editor from the Atom > Keymap menu.
+Atom also has a few movement and selection commands that don't have keybindings by default. You can access these commands from the [Command Palette](/getting-started/sections/atom-basics/#command-palette), but if you find yourself using commands that don't have a keybinding often, have no fear! You can easily add an entry to your `keymap.cson` to create a key combination. You can open `keymap.cson` file in an editor from the Atom > Keymap menu.
 
-For example,  the command `editor:move-to-beginning-of-screen-line` is available in the command palette, but it's not bound to any key combination.  To create a key combination you need to add an entry in your `keymap.cson` file.    For `editor:select-to-previous-word-boundary`, you can add the following to your `keymap.cson`:
+For example, the command `editor:move-to-beginning-of-screen-line` is available in the command palette, but it's not bound to any key combination. To create a key combination you need to add an entry in your `keymap.cson` file. For `editor:select-to-previous-word-boundary`, you can add the following to your `keymap.cson`:
 
 
 {{#mac}}

--- a/content/using-atom/sections/moving-in-atom.md
+++ b/content/using-atom/sections/moving-in-atom.md
@@ -43,7 +43,9 @@ You can also move directly to a specific line (and column) number with <kbd clas
 
 #### Additional Movement and Selection Commands
 
-Atom also has a few movement commands that aren't binded to any keyboard shortcut.   You can access these commands from the [Command Palatte](http://flight-manual.atom.io/getting-started/sections/atom-basics/#command-palette), but if you find yourself using a commands that doesn't have a keyboard shortcut often, have no fear!  You can easily add a entry to your `keymaps.cson` to create a keyboard shortcut.  For example,  the command `editor:move-to-beginning-of-screen-line` is available in the command palette, but not binded to any keyboard shortcut.  If you would like this to have a keyboard shortcut, you can add a entry in your `keymaps.cson` file.   For `editor:select-to-previous-word-boundary`, you can add the following to your `keymaps.cson`:
+Atom also has a few movement and selection commands that don't have a keyboard shortcut mapped to it.   You can access these commands from the [Command Palatte](http://flight-manual.atom.io/getting-started/sections/atom-basics/#command-palette), but if you find yourself using a command that doesn't have a keyboard shortcut often, have no fear!  You can easily add a entry to your `keymaps.cson` to create a keyboard shortcut.  
+
+For example,  the command `editor:move-to-beginning-of-screen-line` is available in the command palette, but it's not binded to any keyboard shortcut.  To add create a keyboard shortcut you need to add a entry in your `keymaps.cson` file.   For `editor:select-to-previous-word-boundary`, you can add the following to your `keymaps.cson`:
 
 {{#mac}}
 ```coffee

--- a/content/using-atom/sections/moving-in-atom.md
+++ b/content/using-atom/sections/moving-in-atom.md
@@ -43,7 +43,7 @@ You can also move directly to a specific line (and column) number with <kbd clas
 
 #### Additional Movement and Selection Commands
 
-Atom also has a few movement and selection commands that don't have keybindings by default. You can access these commands from the [Command Palette](/getting-started/sections/atom-basics/#command-palette), but if you find yourself using commands that don't have a keybinding often, have no fear! You can easily add an entry to your `keymap.cson` to create a key combination. You can open `keymap.cson` file in an editor from the Atom > Keymap menu.
+Atom also has a few movement and selection commands that don't have keybindings by default. You can access these commands from the [Command Palette](/getting-started/sections/atom-basics/#command-palette), but if you find yourself using commands that don't have a keybinding often, have no fear! You can easily add an entry to your `keymap.cson` to create a key combination. You can open `keymap.cson` file in an editor from the <span class="platform-mac">_Atom > Keymap_</span><span class="platform-windows">_File > Keymap_</span><span class="platform-linux">_Edit > Keymap_</span> menu.
 
 For example, the command `editor:move-to-beginning-of-screen-line` is available in the command palette, but it's not bound to any key combination. To create a key combination you need to add an entry in your `keymap.cson` file. For `editor:select-to-previous-word-boundary`, you can add the following to your `keymap.cson`:
 


### PR DESCRIPTION
Atom has a few movement commands that exist, but aren't binded to any keyboard shortcut so they are hard to find unless you just know what exactly to type in the command palette.  This PR adds a section that makes it transparent what those commands (per platform), and tells people how to add a keyboard shortcut by adding a entry in keymaps.

Thanks @nathansobo for syncing up on this!  

Additional feedback would be awesome!  

/cc @lee-dohm @nathansobo @lukehefson @rsese 