### PR TITLE
Add a list of useful resources

### DIFF
--- a/content/hacking-atom/sections/creating-a-grammar.md
+++ b/content/hacking-atom/sections/creating-a-grammar.md
@@ -183,7 +183,7 @@ However, including `source.gfm` has led to another problem: note blocks still do
 ]
 ```
 
-#### Where to go from here
+#### Where to Go from Here
 
 There are several good resources out there that help when writing a grammar. The following is a list of some particularly useful ones (some have been linked to in the sections above as well).
 

--- a/content/hacking-atom/sections/creating-a-grammar.md
+++ b/content/hacking-atom/sections/creating-a-grammar.md
@@ -18,6 +18,7 @@ Grammars depend heavily on regexes, and you should be comfortable with interpret
 * https://www.regular-expressions.info/tutorial.html provides a comprehensive regex tutorial
 * https://www.rexegg.com/regex-quickstart.html contains a cheat sheet for various regex expressions
 * https://regex101.com/ or https://regexr.com/ allows live prototyping
+* https://github.com/kkos/oniguruma/blob/master/doc/RE the docs for the Oniguruma regex engine
 
 Grammar files are written in the [CSON](https://github.com/bevry/cson#what-is-cson) or [JSON](https://www.json.org/) format. Whichever one you decide to use is up to you, but this tutorial will be written in CSON.
 
@@ -181,6 +182,18 @@ However, including `source.gfm` has led to another problem: note blocks still do
   }
 ]
 ```
+
+#### Where to go from here
+
+There are several good resources out there that help when writing a grammar. The following is a list of some particularly useful ones (some have been linked to in the sections above as well).
+
+- [DamnedScholar's Gist](https://gist.github.com/DamnedScholar/622926bcd222eb1ddc483d12103fd315). Provides a template of most keys, each with a short comment explaining their function.
+- [Aerijo's Gist](https://gist.github.com/Aerijo/b8c82d647db783187804e86fa0a604a1). [Work in Progress] Another guide that attempts to fully explain making a grammar package for users of all levels.
+- http://www.apeth.com/nonblog/stories/textmatebundle.html. A blog of a programmer's experience writing a grammar package for TextMate.
+- [Oniguruma docs](https://github.com/kkos/oniguruma/blob/master/doc/RE). The documentation for the regex engine Atom uses.
+- [TextMate Section 12](http://manual.macromates.com/en/language_grammars.html). Atom uses the same principles as laid out here, including the list of acceptable scopes.
+- [`first-mate`](https://github.com/atom/first-mate). Not necessary to write a grammar, but a good technical reference for what Atom is doing behind the scenes.
+- Look at any existing packages, such as the ones for [Python](https://github.com/atom/language-python), [JavaScript](https://github.com/atom/language-javascript), [HTML](https://github.com/atom/language-html), [and more](https://github.com/atom?utf8=%E2%9C%93&q=language&type=source&language=).
 
 <!--
 TODO:

--- a/content/hacking-atom/sections/creating-a-grammar.md
+++ b/content/hacking-atom/sections/creating-a-grammar.md
@@ -195,6 +195,7 @@ There are several good resources out there that help when writing a grammar. The
 - [`first-mate`](https://github.com/atom/first-mate). Not necessary to write a grammar, but a good technical reference for what Atom is doing behind the scenes.
 - Look at any existing packages, such as the ones for [Python](https://github.com/atom/language-python), [JavaScript](https://github.com/atom/language-javascript), [HTML](https://github.com/atom/language-html), [and more](https://github.com/atom?utf8=%E2%9C%93&q=language&type=source&language=).
 
+
 <!--
 TODO:
 * `repository` and including from repository patterns


### PR DESCRIPTION
The first change is to add a link to the Oniguruma docs in the section about regular expressions. I feel this is important, to definitively point people to the right documentation.

The second change is to add a new section with links to other guides / useful information. My own guide was suggested to be included by @50Wliu, but I felt the others are all excellent as well (I know I depended on them). As I say in the short description, some links are present earlier in the guide. However, I feel it's good to have them all grouped together as well, to centralise everything.

I'm open to any suggested changes. I chose to use linked text instead of the raw links (in most cases) as I feel it helps explain the purpose of the link.