### PR TITLE
Add a standard margin to alerts and highlights.

### DIFF
--- a/assets/stylesheets/app/_syntax.scss
+++ b/assets/stylesheets/app/_syntax.scss
@@ -2,6 +2,7 @@
 
 .highlight  {
   background: #ffffff;
+  margin: $margin 0;
 
   // Comment
   .c { color: #999988; font-style: italic }

--- a/assets/stylesheets/shared/_markdown.scss
+++ b/assets/stylesheets/shared/_markdown.scss
@@ -30,7 +30,7 @@ $warning-color     : #d06806;
 
   .alert {
     position:relative;
-    margin:0 auto;
+    margin: $margin auto;
     padding:15px;
     font-size:16px;
     color:#264c72;


### PR DESCRIPTION
The margin is defined in Primer (vendor/primer/_markdown.scss).

Change preview:

![margin-fix](https://user-images.githubusercontent.com/66961/36641556-92c259e4-1a31-11e8-911c-5be7658d9c13.png)
