### PR TITLE
Note about modifications to the atom command

### DIFF
--- a/content/hacking-atom/sections/hacking-on-atom-core.md
+++ b/content/hacking-atom/sections/hacking-on-atom-core.md
@@ -31,6 +31,11 @@ Once you have a local copy of Atom cloned and bootstrapped, you can then run Ato
 ``` command-line
 $ atom --dev <em>path-to-open</em>
 ```
+{{#note}}
+
+**Note:** If the atom command does not respond in the terminal, then try atom-dev or atom-beta. The suffix depends upon the particular source code that was cloned.
+
+{{/note}}
 
 There are a couple benefits of running Atom in Dev Mode:
 


### PR DESCRIPTION
Due to the change to install-application.js, the atom command may now be atom, atom-beta, or atom-dev depending upon the version of the source. Since -dev can be in the master branch, this note should be added for clarity.