### PR TITLE
correct mac keybingings

### DIFF
--- a/content/using-atom/sections/folding.md
+++ b/content/using-atom/sections/folding.md
@@ -5,10 +5,12 @@ title: Folding
 
 If you want to see an overview of the structure of the code file you're working on, folding can be a helpful tool. Folding hides blocks of code such as functions or looping blocks in order to simplify what is on your screen.
 
-You can fold blocks of code by clicking the arrows that appear when you hover your mouse cursor over the gutter. You can also fold and unfold from the keyboard with the <kbd class="platform-mac">Alt+Cmd+[</kbd><kbd class="platform-windows platform-linux">Alt+Ctrl+[</kbd> and <kbd class="platform-mac">Alt+Cmd+]</kbd><kbd class="platform-windows platform-linux">Alt+Ctrl+]</kbd> keybindings.
+You can fold blocks of code by clicking the arrows that appear when you hover your mouse cursor over the gutter. You can also fold and unfold from the keyboard with the <kbd class="platform-mac">⌥+⌘+[</kbd><kbd class="platform-windows platform-linux">Alt+Ctrl+[</kbd> and <kbd class="platform-mac">⌥+⌘+]</kbd><kbd class="platform-windows platform-linux">Alt+Ctrl+]</kbd> keybindings.
 
 ![Code folding example](../../images/folding.png "Code folding example")
 
-To fold everything, use <kbd class="platform-mac">Alt+Cmd+Shift+[</kbd><kbd class="platform-windows platform-linux">Alt+Ctrl+Shift+[</kbd> and to unfold everything use <kbd class="platform-mac">Alt+Cmd+Shift+]</kbd><kbd class="platform-windows platform-linux">Alt+Ctrl+Shift+]</kbd>. You can also fold at a specific indentation level with <kbd class="platform-mac">Cmd+K</kbd><kbd class="platform-windows platform-linux">Ctrl+K</kbd> <kbd class="platform-mac">Cmd+0-9</kbd><kbd class="platform-windows platform-linux">Ctrl+0-9</kbd> where the number is the indentation depth.
+To fold everything, use <kbd class="platform-mac">⌥+⌘+Shift+[</kbd><kbd class="platform-windows platform-linux">Alt+Ctrl+Shift+[</kbd> and to unfold everything use <kbd class="platform-mac">⌥+⌘+Shift+]</kbd><kbd class="platform-windows platform-linux">Alt+Ctrl+Shift+]</kbd>. You can also fold at a specific indentation level with <kbd class="platform-mac">Cmd+K</kbd><kbd class="platform-windows platform-linux">Ctrl+K</kbd> <kbd class="platform-mac">Cmd+0-9</kbd><kbd class="platform-windows platform-linux">Ctrl+0-9</kbd> where the number is the indentation depth.
 
-Finally, you can fold arbitrary sections of your code or text by making a selection and then typing <kbd class="platform-mac">Alt+Cmd+Ctrl+F</kbd><kbd class="platform-windows platform-linux">Alt+Ctrl+F</kbd> or choosing "Fold Selection" in the Command Palette.
+Finally, you can fold arbitrary sections of your code or text by making a selection and then typing <kbd class="platform-mac">⌥+⌘++Ctrl+F</kbd><kbd class="platform-windows platform-linux">Alt+Ctrl+F</kbd> or choosing "Fold Selection" in the Command Palette.
+
+⌘-k cmd+N


### PR DESCRIPTION
Sourced from https://gist.github.com/chrissimpkins/5bf5686bae86b8129bee
and tested locally on two mac computers with different environments.