### PR TITLE
Fixes issue #10138

### DIFF
--- a/content/hacking-atom/sections/hacking-on-atom-core.md
+++ b/content/hacking-atom/sections/hacking-on-atom-core.md
@@ -24,6 +24,13 @@ $ cd <em>where-you-cloned-atom</em>
 $ script/bootstrap
 ```
 
+###### Ubuntu / Debian
+If the bootstrap script fails, install GNOME headers and other basic prerequisites:
+
+  ``` command-line
+  $ sudo apt-get install build-essential git libsecret-1-dev fakeroot rpm libx11-dev libxkbfile-dev
+  ```
+
 #### Running in Development Mode
 
 Once you have a local copy of Atom cloned and bootstrapped, you can then run Atom in Development Mode. But first, if you cloned Atom to somewhere other than <span class="platform-mac platform-linux">`~/github/atom`</span><span class="platform-windows">`%USERPROFILE%\github\atom`</span> you will need to set the `ATOM_DEV_RESOURCE_PATH` environment variable to point to the folder in which you cloned Atom. To run Atom in Dev Mode, use the `--dev` parameter from the terminal:


### PR DESCRIPTION
Please see the errors described in:
* https://github.com/atom/atom/issues/10138
* https://github.com/atom/atom/issues/15155

When running bootstrap script there occurred an error:

    ENOENT: no such file or directory, rename '/some/path/node_modules/module' -> /some/node_modules/.module.delete

Installing the dependencies described in the 'Building' section solves the problem and the bootstrap script finishes without errors.