### PR TITLE
Add additional information about regex to find-and-replace.md

### DIFF
--- a/content/using-atom/sections/find-and-replace.md
+++ b/content/using-atom/sections/find-and-replace.md
@@ -18,7 +18,9 @@ If you type a string in the replacement text box, you can replace matches with a
 
 {{#note}}
 
-**Note:** With a regular expression search, the replacement syntax to refer back to search groups is  $1, $2, … $& 
+**Note:** Atom uses JavaScript regular expressions to perform regular expression searches.
+
+When doing a regular expression search, the replacement syntax to refer back to search groups is  $1, $2, … $&. Refer to JavaScript's [guide to regular expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) to learn more about regular expression syntax you can use in Atom.
 
 {{/note}}
 


### PR DESCRIPTION
Fixes #452

- Specified that Atom uses JavaScript regex syntax
- Added a link to JavaScript's documentation