### PR TITLE
Remove the use this approach line

### DIFF
--- a/content/hacking-atom/sections/debugging.md
+++ b/content/hacking-atom/sections/debugging.md
@@ -206,8 +206,6 @@ When an unexpected error occurs in Atom, you will normally see a red notificatio
 
 ![Exception Notification](../../images/exception-notification.png)
 
-If you can reproduce the error, use this approach to get the full stack trace and [report the issue](https://github.com/atom/atom/blob/master/CONTRIBUTING.md#submitting-issues).
-
 Not all errors are logged with a notification so if you suspect you're experiencing an error but there's no notification, you can also look for errors in the developer tools Console tab.  To access the Console tab, press <kbd class="platform-mac">Alt-Cmd-I</kbd><kbd class="platform-windows platform-linux">Ctrl-Shift-I</kbd> to open developer tools and then click the Console tab:
 
 ![DevTools Error](../../images/devtools-error.png)


### PR DESCRIPTION
### Description of the change

This line feels like it should be somewhere else or just removed completely. This section is about checking the developer tools for errors. Not how you get stack traces to report issues.

* It does not specify what approach to use. Just `use this approach`
* The link is not working. Maybe it should be https://github.com/atom/atom/blob/master/CONTRIBUTING.md#reporting-bugs
* You can already reproduce an error if you are checking the developer tools for errors

### Alternative approach

The line could be moved down to the bottom of this section and be reworded to say `"Include this information when opening an issue or question on discuss"`.