### PR TITLE
Add manual publishing process with big danger sign

### DIFF
--- a/content/behind-atom/sections/maintaining-your-packages.md
+++ b/content/behind-atom/sections/maintaining-your-packages.md
@@ -5,6 +5,25 @@ title: Maintaining Your Packages
 
 While publishing is, by far, the most common action you will perform when working with the packages you provide, there are other things you may need to do.
 
+#### Publishing a Package Manually
+
+{{#danger}}
+
+**Danger:** :rotating_light: Publishing a package manually is not a recommended practice and is only for the advanced user who has published packages before. If you perform the steps wrong, you may be unable to publish the new version of your package and may have to completely unpublish your package in order to correct the faulty state. You have been warned.
+
+{{/danger}}
+
+Some people prefer to control every aspect of the package publishing process. Normally, the apm tool manages certain details during publishing to keep things consistent and make everything work smoothly. If you're one of those people that prefers to do things manually, there are certain steps you'll have to take in order to make things work just as smoothly as if apm has taken care of things for you.
+
+When you have completed the changes that you want to publish and are ready to start the publishing process, you must perform the following steps on the `master` branch:
+
+1. Update the version number in your packages `package.json`. The version number **must** match the regular expression: `^\d+\.\d+\.\d+`
+1. Commit the version number change
+1. Create a Git tag referencing the above commit. The tag **must** match the regular expression `^v\d+\.\d+\.\d+` and the part after the `v` **must** match the full text of the version number in the `package.json`
+1. Execute `git push`
+1. Execute `git push --tags`
+1. Execute `apm publish --tag tagname` where `tagname` **must** match the name of the tag created in the above step
+
 #### Adding a Collaborator
 
 Some packages get too big for one person. Sometimes priorities change and someone else wants to help out. You can let others help or create co-owners by [adding them as a collaborator](https://help.github.com/articles/adding-collaborators-to-a-personal-repository/) on the GitHub repository for your package. *Note:* Anyone that has push access to your repository will have the ability to publish new versions of the package that belongs to that repository.

--- a/content/behind-atom/sections/maintaining-your-packages.md
+++ b/content/behind-atom/sections/maintaining-your-packages.md
@@ -20,8 +20,7 @@ When you have completed the changes that you want to publish and are ready to st
 1. Update the version number in your packages `package.json`. The version number **must** match the regular expression: `^\d+\.\d+\.\d+`
 1. Commit the version number change
 1. Create a Git tag referencing the above commit. The tag **must** match the regular expression `^v\d+\.\d+\.\d+` and the part after the `v` **must** match the full text of the version number in the `package.json`
-1. Execute `git push`
-1. Execute `git push --tags`
+1. Execute `git push --follow-tags`
 1. Execute `apm publish --tag tagname` where `tagname` **must** match the name of the tag created in the above step
 
 #### Adding a Collaborator

--- a/content/behind-atom/sections/maintaining-your-packages.md
+++ b/content/behind-atom/sections/maintaining-your-packages.md
@@ -15,6 +15,12 @@ While publishing is, by far, the most common action you will perform when workin
 
 Some people prefer to control every aspect of the package publishing process. Normally, the apm tool manages certain details during publishing to keep things consistent and make everything work smoothly. If you're one of those people that prefers to do things manually, there are certain steps you'll have to take in order to make things work just as smoothly as if apm has taken care of things for you.
 
+{{#note}}
+
+**Note:** The apm tool will only publish and https://atom.io will only list packages that are hosted on [GitHub](https://github.com), regardless of what process is used to publish them.
+
+{{/note}}
+
 When you have completed the changes that you want to publish and are ready to start the publishing process, you must perform the following steps on the `master` branch:
 
 1. Update the version number in your packages `package.json`. The version number **must** match the regular expression: `^\d+\.\d+\.\d+`

--- a/content/behind-atom/sections/maintaining-your-packages.md
+++ b/content/behind-atom/sections/maintaining-your-packages.md
@@ -23,7 +23,7 @@ Some people prefer to control every aspect of the package publishing process. No
 
 When you have completed the changes that you want to publish and are ready to start the publishing process, you must perform the following steps on the `master` branch:
 
-1. Update the version number in your packages `package.json`. The version number **must** match the regular expression: `^\d+\.\d+\.\d+`
+1. Update the version number in your package's `package.json`. The version number **must** match the regular expression: `^\d+\.\d+\.\d+`
 1. Commit the version number change
 1. Create a Git tag referencing the above commit. The tag **must** match the regular expression `^v\d+\.\d+\.\d+` and the part after the `v` **must** match the full text of the version number in the `package.json`
 1. Execute `git push --follow-tags`

--- a/content/hacking-atom/sections/hacking-on-atom-core.md
+++ b/content/hacking-atom/sections/hacking-on-atom-core.md
@@ -75,8 +75,8 @@ In order to build Atom from source, you need to have a number of other requireme
 * 7zip (7z.exe available from the command line) - for creating distribution zip files
 * C++ build tools, either:
   * [Visual C++ Build Tools 2015](https://landinghub.visualstudio.com/visual-cpp-build-tools)
-  * [Visual Studio 2013 Update 5](https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs) (Express Edition or better)
-  * [Visual Studio 2015](https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs) (Community Edition or better)
+  * [Visual Studio 2013 Update 5](https://www.visualstudio.com/downloads/) (Express Edition or better)
+  * [Visual Studio 2015](https://www.visualstudio.com/downloads/) (Community Edition or better)
   * **Unsupported** but more convenient for some who know Node: [windows-build-tools](https://www.npmjs.com/package/windows-build-tools)
 
 


### PR DESCRIPTION
Some people insist on publishing packages manually. Give them the instructions to not shoot themselves in the foot but with a big danger sign so they know they're on their own.

Fixes #459 

/cc @Ben3eeE @Arcanemagus @rsese for extra :eyes: