### PR TITLE
adding theme color to octicon-heart

### DIFF
--- a/assets/stylesheets/app/_main.scss
+++ b/assets/stylesheets/app/_main.scss
@@ -242,7 +242,11 @@ hr {
     font-size: 20px;
     top: 1px;
   }
-
+	
+  .octicon-heart {
+		color: #40a977;
+	}
+	
   .octicon-logo-github {
     top: 2px;
   }


### PR DESCRIPTION
The `octicon-heart` icon looks better in theme color(`#40a977`)

**Output**
![image](https://user-images.githubusercontent.com/13312568/38878456-a3d8b6f4-427e-11e8-81aa-76cbd77cecce.png)
