### PR TITLE
Break commands in two lines at linux install instructions

### DIFF
--- a/content/getting-started/sections/installing-atom.md
+++ b/content/getting-started/sections/installing-atom.md
@@ -78,7 +78,8 @@ To install Atom on Debian, Ubuntu, or related distributions, add our official
 package repository to your system by running the following commands:
 
 ``` command-line
-$ curl -L https://packagecloud.io/AtomEditor/atom/gpgkey | sudo apt-key add -
+$ curl -L https://packagecloud.io/AtomEditor/atom/gpgkey
+$ sudo apt-key add -
 $ sudo sh -c 'echo "deb [arch=amd64] https://packagecloud.io/AtomEditor/atom/any/ any main" > /etc/apt/sources.list.d/atom.list'
 $ sudo apt-get update
 ```


### PR DESCRIPTION
## Description 

When the commands are put together in the same line at bash, the admin password and curl prompts are mixed at bash, which may lead to a confusing experience for the Atom's users during the installation process (the user may not see at first the sudo prompt and keep waiting for the curl result). Thanks for considering this little change.

![image](https://user-images.githubusercontent.com/20022063/39608818-9857b926-4f1a-11e8-92c1-33bd3e889294.png)

## Environment

- Operating System: Ubuntu Linux 17.10

## Notes
 
Sorry about the branch name, I've just made the change though GitHub's interface.