### PR TITLE
Clarify movement and selection commands without default keybindings

### DIFF
--- a/content/using-atom/sections/moving-in-atom.md
+++ b/content/using-atom/sections/moving-in-atom.md
@@ -71,10 +71,9 @@ For example, the command `editor:move-to-beginning-of-screen-line` is available 
 
 This will bind the command `editor:select-to-previous-word-boundary` to <kbd class="platform-mac">Cmd+Shift+E</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+E</kbd>.  For more information on customizing your keybindings, see [Customizing Keybindings](/using-atom/sections/basic-customization/#customizing-keybindings).
 
-Here's a list of Movement and Selection Commands that have a keyboard shortcut by default:
+Here's a list of Movement and Selection Commands that do not have a keyboard shortcut by default:
 
 {{#mac}}
-
 ```
 editor:move-to-beginning-of-next-paragraph
 editor:move-to-beginning-of-previous-paragraph
@@ -83,11 +82,9 @@ editor:move-to-beginning-of-line
 editor:move-to-beginning-of-next-word
 editor:move-to-previous-word-boundary
 editor:move-to-next-word-boundary
-editor:move-to-previous-subword-boundary
+editor:select-to-beginning-of-next-paragraph
 editor:select-to-beginning-of-previous-paragraph
-editor:select-to-end-of-line
 editor:select-to-beginning-of-line
-editor:select-to-beginning-of-word
 editor:select-to-beginning-of-next-word
 editor:select-to-next-word-boundary
 editor:select-to-previous-word-boundary
@@ -110,7 +107,6 @@ editor:select-to-beginning-of-next-paragraph
 editor:select-to-beginning-of-previous-paragraph
 editor:select-to-end-of-line
 editor:select-to-beginning-of-line
-editor:select-to-beginning-of-word
 editor:select-to-beginning-of-next-word
 editor:select-to-next-word-boundary
 editor:select-to-previous-word-boundary
@@ -133,7 +129,6 @@ editor:select-to-beginning-of-next-paragraph
 editor:select-to-beginning-of-previous-paragraph
 editor:select-to-end-of-line
 editor:select-to-beginning-of-line
-editor:select-to-beginning-of-word
 editor:select-to-beginning-of-next-word
 editor:select-to-next-word-boundary
 editor:select-to-previous-word-boundary


### PR DESCRIPTION
I updated "Additional Movement and Selection Commands" to make it clear these commands do not have default keybindings. This comes after checking intentions for the section in issue https://github.com/atom/flight-manual.atom.io/issues/465.

Comparing the Mac, Win32 and Linux lists against current keymaps, I found some key combinations that _are_ bound by default and removed them from the appropriate lists.