### PR TITLE
Added bullet about live reloading

### DIFF
--- a/content/hacking-atom/sections/hacking-on-atom-core.md
+++ b/content/hacking-atom/sections/hacking-on-atom-core.md
@@ -41,6 +41,7 @@ There are a couple benefits of running Atom in Dev Mode:
 
 1. When the `ATOM_DEV_RESOURCE_PATH` environment variable is set correctly, Atom is run using the source code from your local `atom/atom` repository. This means that you don't have to run <span class="platform-mac platform-linux">`script/build`</span><span class="platform-windows">`script\build`</span> every time you change code. Just restart Atom 👍
 1. Packages that exist in <span class="platform-mac platform-linux">`~/.atom/dev/packages`</span><span class="platform-windows">`%USERPROFILE%\.atom\dev\packages`</span> are loaded instead of packages of the same name normally loaded from other locations. This means that you can have development versions of packages you use loaded but easily go back to the stable versions by launching without Dev Mode.
+1. Packages that contain stylesheets, such as syntax themes, will have those stylesheets automatically reloaded by the [dev-live-reload](https://github.com/atom/dev-live-reload) package. This does not live reload javascript or coffeescript files, you'll need to reload the window (`window:reload`) to see changes to those.
 
 #### Running Atom Core Tests Locally
 

--- a/content/hacking-atom/sections/hacking-on-atom-core.md
+++ b/content/hacking-atom/sections/hacking-on-atom-core.md
@@ -41,7 +41,7 @@ There are a couple benefits of running Atom in Dev Mode:
 
 1. When the `ATOM_DEV_RESOURCE_PATH` environment variable is set correctly, Atom is run using the source code from your local `atom/atom` repository. This means that you don't have to run <span class="platform-mac platform-linux">`script/build`</span><span class="platform-windows">`script\build`</span> every time you change code. Just restart Atom 👍
 1. Packages that exist in <span class="platform-mac platform-linux">`~/.atom/dev/packages`</span><span class="platform-windows">`%USERPROFILE%\.atom\dev\packages`</span> are loaded instead of packages of the same name normally loaded from other locations. This means that you can have development versions of packages you use loaded but easily go back to the stable versions by launching without Dev Mode.
-1. Packages that contain stylesheets, such as syntax themes, will have those stylesheets automatically reloaded by the [dev-live-reload](https://github.com/atom/dev-live-reload) package. This does not live reload javascript or coffeescript files, you'll need to reload the window (`window:reload`) to see changes to those.
+1. Packages that contain stylesheets, such as syntax themes, will have those stylesheets automatically reloaded by the [dev-live-reload](https://github.com/atom/dev-live-reload) package. This does not live reload JavaScript or CoffeeScript files — you'll need to reload the window (`window:reload`) to see changes to those.
 
 #### Running Atom Core Tests Locally
 


### PR DESCRIPTION
This clarifies a lot of the confusion that I (and others) had on the #packages channel today.

Tangentially related, this package is really hard to hack on. Ruby 2.2.3 is almost 3 years old at this point. 2.5.1 is the latest. I was able to get it to bundle just using bundle directly, but script/bootstrap failed to install Nokogiri (lack of necessary headers?). Then I ran script/server, and got a different failure. I would include the logs for those here, but I tried to update npm and got a blue screen of death.

Therefore I haven't properly tested these changes, since I can't get the server to run for me. Shouldn't be any problems since it's just normal markdown.