### PR TITLE
Fix broken link in hacking-on-atom-core.md

### DIFF
--- a/content/hacking-atom/sections/hacking-on-atom-core.md
+++ b/content/hacking-atom/sections/hacking-on-atom-core.md
@@ -75,7 +75,7 @@ In order to build Atom from source, you need to have a number of other requireme
   * The `python.exe` must be available at `%SystemDrive%\Python27\python.exe`. If it is installed elsewhere create a symbolic link to the directory containing the `python.exe` using: `mklink /d %SystemDrive%\Python27 D:\elsewhere\Python27`
 * 7zip (7z.exe available from the command line) - for creating distribution zip files
 * C++ build tools, either:
-  * [Visual C++ Build Tools 2015](https://landinghub.visualstudio.com/visual-cpp-build-tools)
+  * [Visual C++ Build Tools 2015](https://visualstudio.microsoft.com/vs/older-downloads/)
   * [Visual Studio 2013 Update 5](https://www.visualstudio.com/downloads/) (Express Edition or better)
   * [Visual Studio 2015](https://www.visualstudio.com/downloads/) (Community Edition or better)
   * **Unsupported** but more convenient for some who know Node: [windows-build-tools](https://www.npmjs.com/package/windows-build-tools)


### PR DESCRIPTION
This PR updates the outdated link of VC2015 build tools in ```hacking-on-atom-core.md```, in order to fix the error thrown by HTML-Proofer. This should also fix the error returned in #472 .