### PR TITLE
Docs for `root-scope-used`

### DIFF
--- a/content/hacking-atom/sections/package-active-editor-info.md
+++ b/content/hacking-atom/sections/package-active-editor-info.md
@@ -114,7 +114,7 @@ The purpose of our view is to show information about the active text editor, so 
   }
 ```
 
-Now our item will appear in the right dock intially and users will only be able to drag it to one of the other docks.
+Now our item will appear in the right dock initially and users will only be able to drag it to one of the other docks.
 
 #### Show Active Editor Info
 

--- a/content/hacking-atom/sections/package-word-count.md
+++ b/content/hacking-atom/sections/package-word-count.md
@@ -55,7 +55,8 @@ style sheets your package needs to load. If not specified, style sheets in the `
   *  `core:loaded-shell-environment`,
   *  `language-package-name:grammar-used` (e.g., `language-javascript:grammar-used`), and  
   * `language-scope:root-scope-used` (e.g., `source.js:root-scope-used`).  
-  Using the `root-scope` hook allows your package to be provider agnostic; it will activate when any file using that root scope is opened, regardless of what package is providing the scope. In contrast, the `grammar-used` hook will activate it when any grammar from a particular language package is activated. The `root-scope` hook should be preferred, as it allows users to use different language packages without you needing to add each one to the activation hooks. Language package authors are encouraged to keep scope names consistent with each other to aid in this.
+  Using the `root-scope` hook allows your package to be provider agnostic; it will activate when any file using that root scope is opened, regardless of what package is providing the scope. In contrast, the `grammar-used` hook will activate it when any grammar from a particular language package is activated. The `root-scope` hook should be preferred, as it allows users to use different language packages without you needing to add each one to the activation hooks. Language package authors are encouraged to keep scope names consistent with each other to aid in this.  
+  If using the `root-scope` hook, you should also declare your Atom engine compatibility as `>= 1.30.0 < 2.0.0`.
 
 The `package.json` in the package we've just generated looks like this currently:
 

--- a/content/hacking-atom/sections/package-word-count.md
+++ b/content/hacking-atom/sections/package-word-count.md
@@ -51,7 +51,11 @@ style sheets your package needs to load. If not specified, style sheets in the `
 * `menus`: an Array of Strings identifying the order of the menu mappings your package needs to load. If not specified, mappings in the `menus` directory are added alphabetically.
 * `snippets`: an Array of Strings identifying the order of the snippets your package needs to load. If not specified, snippets in the `snippets` directory are added alphabetically.
 * `activationCommands`: an Object identifying commands that trigger your package's activation. The keys are CSS selectors, the values are Arrays of Strings identifying the command. The loading of your package is delayed until one of these events is triggered within the associated scope defined by the CSS selector.  If not specified, the `activate()` method of your main export will be called when your package is loaded.
-* `activationHooks`: an Array of Strings identifying hooks that trigger your package's activation. The loading of your package is delayed until one of these hooks are triggered. Currently, there are two activation hooks: `language-package-name:grammar-used` (e.g., `language-javascript:grammar-used`) and `core:loaded-shell-environment`.
+* `activationHooks`: an Array of Strings identifying hooks that trigger your package's activation. The loading of your package is delayed until one of these hooks are triggered. Currently, there are three activation hooks:
+  *  `language-package-name:grammar-used` (e.g., `language-javascript:grammar-used`),
+  * `language-scope:root-scope-used` (e.g., `javascript:root-scope-used` or `source.gfm:root-scope-used`), and
+  *  `core:loaded-shell-environment`.
+  For the `root-scope-used` hook, the root scope is the one declared by a TextMate grammar, or the `id` declared by a Tree-sitter grammar. Note that these are often different, so add both if they exist to ensure proper activation.
 
 The `package.json` in the package we've just generated looks like this currently:
 

--- a/content/hacking-atom/sections/package-word-count.md
+++ b/content/hacking-atom/sections/package-word-count.md
@@ -52,10 +52,10 @@ style sheets your package needs to load. If not specified, style sheets in the `
 * `snippets`: an Array of Strings identifying the order of the snippets your package needs to load. If not specified, snippets in the `snippets` directory are added alphabetically.
 * `activationCommands`: an Object identifying commands that trigger your package's activation. The keys are CSS selectors, the values are Arrays of Strings identifying the command. The loading of your package is delayed until one of these events is triggered within the associated scope defined by the CSS selector.  If not specified, the `activate()` method of your main export will be called when your package is loaded.
 * `activationHooks`: an Array of Strings identifying hooks that trigger your package's activation. The loading of your package is delayed until one of these hooks are triggered. Currently, there are three activation hooks:
-  *  `language-package-name:grammar-used` (e.g., `language-javascript:grammar-used`),
-  * `language-scope:root-scope-used` (e.g., `javascript:root-scope-used` or `source.gfm:root-scope-used`), and
-  *  `core:loaded-shell-environment`.
-  For the `root-scope-used` hook, the root scope is the one declared by a TextMate grammar, or the `id` declared by a Tree-sitter grammar. Note that these are often different, so add both if they exist to ensure proper activation.
+  *  `core:loaded-shell-environment`,
+  *  `language-package-name:grammar-used` (e.g., `language-javascript:grammar-used`), and  
+  * `language-scope:root-scope-used` (e.g., `source.js:root-scope-used`).  
+  Using the `root-scope` hook allows your package to be provider agnostic; it will activate when any file using that root scope is opened, regardless of what package is providing the scope. In contrast, the `grammar-used` hook will activate it when any grammar from a particular language package is activated. The `root-scope` hook should be preferred, as it allows users to use different language packages without you needing to add each one to the activation hooks. Language package authors are encouraged to keep scope names consistent with each other to aid in this.
 
 The `package.json` in the package we've just generated looks like this currently:
 


### PR DESCRIPTION
Initial write up of docs for this activation hook. I'm thinking I should also add more on which hook to pick. Something like
  - `grammar-used` if it is any grammar in a specific package you want to activate on
  - `root-scope-used` if the package providing the grammar does not matter, and you only want to activate when the right language is used. A better explanation on the differences between TextMate and Tree-sitter might be needed, or a link to where the reader can learn more.

Related atom/atom#17521

I also found and fixed a typo, hope that's OK.