### PR TITLE
Add parser build warning

### DIFF
--- a/content/hacking-atom/sections/creating-a-grammar.md
+++ b/content/hacking-atom/sections/creating-a-grammar.md
@@ -38,6 +38,12 @@ Once you have created a parser, you need to publish it to [the NPM registry](htt
 
 then run the command `npm publish`.
 
+{{#warning}}
+
+**Warning:** By default the user will need to build the parser on their personal computer before it can be used in Atom. This requires them to have the proper build tools and environment, which is often difficult or impossible to set up. Instead, consider implementing a CI deployment workflow. Properly configured, it will upload prebuilt binaries of the parser for every major platform each time you publish a release. You can find detailed instructions on how to do this [here]().
+
+{{/warning}}
+
 #### The Package
 
 Once you have a Tree-sitter parser that is available on npm, you can use it in your Atom package. Packages with grammars are, by convention, always named starting with _language_. You'll need a folder with a `package.json`, a `grammars` subdirectory, and a single `json` or `cson` file in the `grammars` directory, which can be named anything.


### PR DESCRIPTION
This is an eye-catching block that shouts about parsers needing to be prebuilt.

I still need to make / write the gist about how to set it up. Alternatively, and appendix in the flight manual might be better.

Either way, I don't want to add any more to the section here. The steps, with enough templates and images, would be considerably long.

CI fails because the link is blank currently. Change in action:
____

<img width="726" alt="screen shot 2018-09-06 at 4 19 07 pm" src="https://user-images.githubusercontent.com/22167388/45138909-6c7a7700-b1f1-11e8-9d17-3bd2f79dc9e6.png">
