### PR TITLE
Undo discard documentation

### DIFF
--- a/content/using-atom/sections/github-package.md
+++ b/content/using-atom/sections/github-package.md
@@ -84,6 +84,7 @@ If you no longer want to keep some changes, you can discard them. It's similar t
 
 ![Discard changes](../../images/github-discard.png "Discard changes")
 
+If you want to cancel discarding some changes, you can restore them, using the same context menu. It's similar to cherry-picking, where "their" changes are the ones you previously discarded.
 
 #### Commit
 

--- a/content/using-atom/sections/github-package.md
+++ b/content/using-atom/sections/github-package.md
@@ -82,9 +82,9 @@ If you no longer want to keep some changes, you can discard them. It's similar t
 - **Hunk**: Click on the trash icon in the top bar of a hunk.
 - **Lines**: Right-click on a line (or multiple) and choose "Discard Selection".
 
-![Discard changes](../../images/github-discard.png "Discard changes")
-
 If you want to cancel discarding some changes, you can restore them, using the same context menu. It's similar to cherry-picking, where "their" changes are the ones you previously discarded.
+
+![Discard changes](../../images/github-discard.png "Discard changes")
 
 #### Commit
 


### PR DESCRIPTION
Fixes atom/github#1716.

Added mention of the undo discard functionality, as redesigned with atom/github#1702.
I tried being simple and concise, and to match the writing style of the rest of the manual.

I don't think an additional screenshot is necessary, seeing as the newer one for the Discard functionality itself does display the "Undo Last Discard" action in an _available_ state, quite visibly.

Well, that; and, I'm worried I'd start breaking things that I don't wanna spend time fixing if I try and install unpublished/unstable packages! 🙄