### PR TITLE
fix calling bootstrap on windows

### DIFF
--- a/content/hacking-atom/sections/hacking-on-atom-core.md
+++ b/content/hacking-atom/sections/hacking-on-atom-core.md
@@ -19,18 +19,32 @@ $ git clone git@github.com:<em>your-username</em>/atom.git
 
 From there, you can navigate into the directory where you've cloned the Atom source code and run the bootstrap script to install all the required dependencies:
 
-<span class="platform-mac platform-linux">
+{{#mac}}
+
 ``` command-line
 $ cd <em>where-you-cloned-atom</em>
 $ script/bootstrap
 ```
-</span>
-<span class="platform-windows">
+
+{{/mac}}
+
+{{#linux}}
+
+``` command-line
+$ cd <em>where-you-cloned-atom</em>
+$ script/bootstrap
+```
+
+{{/linux}}
+ 
+{{#windows}}
+
 ``` command-line
 $ cd <em>where-you-cloned-atom</em>
 $ script\bootstrap
 ```
-</span>
+
+{{/windows}}
 
 #### Running in Development Mode
 
@@ -169,11 +183,11 @@ $ sudo zypper install nodejs nodejs-devel make gcc gcc-c++ glibc-devel git-core 
 
 ##### Instructions
 
+{{#mac}}
+
 ``` command-line
 $ script/build
 ```
-
-{{#mac}}
 
 To also install the newly built application, use `script/build --install`.
 
@@ -181,19 +195,27 @@ To also install the newly built application, use `script/build --install`.
 
 {{#windows}}
 
+``` command-line
+$ script\build
+```
+
 To also install the newly built application, use `script\build --create-windows-installer` and launch one of the generated installers.
 
 {{/windows}}
 
 {{#linux}}
 
+``` command-line
+$ script/build
+```
+
 To also install the newly built application, use the `--create-debian-package` or `--create-rpm-package` option and then install the generated package via the system package manager.
 
 {{/linux}}
 
-##### `script/build` Options
-
 {{#mac}}
+
+##### `script/build` Options
 
 * `--code-sign`: signs the application with the GitHub certificate specified in `$ATOM_MAC_CODE_SIGNING_CERT_DOWNLOAD_URL`.
 * `--compress-artifacts`: zips the generated application as `out/atom-mac.zip`.
@@ -203,6 +225,8 @@ To also install the newly built application, use the `--create-debian-package` o
 
 {{#windows}}
 
+##### `script\build` Options
+
 * `--code-sign`: signs the application with the GitHub certificate specified in `$WIN_P12KEY_URL`.
 * `--compress-artifacts`: zips the generated application as `out\atom-windows.zip` (requires [7-Zip](http://www.7-zip.org)).
 * `--create-windows-installer`: creates an `.exe` and two `.nupkg` packages in the `out` directory.
@@ -211,6 +235,8 @@ To also install the newly built application, use the `--create-debian-package` o
 {{/windows}}
 
 {{#linux}}
+
+##### `script/build` Options
 
 * `--compress-artifacts`: zips the generated application as `out/atom-{arch}.tar.gz`.
 * `--create-debian-package`: creates a .deb package as `out/atom-{arch}.deb`

--- a/content/hacking-atom/sections/hacking-on-atom-core.md
+++ b/content/hacking-atom/sections/hacking-on-atom-core.md
@@ -21,7 +21,7 @@ From there, you can navigate into the directory where you've cloned the Atom sou
 
 ``` command-line
 $ cd <em>where-you-cloned-atom</em>
-$ script/bootstrap
+$ script\bootstrap
 ```
 
 #### Running in Development Mode

--- a/content/hacking-atom/sections/hacking-on-atom-core.md
+++ b/content/hacking-atom/sections/hacking-on-atom-core.md
@@ -19,10 +19,18 @@ $ git clone git@github.com:<em>your-username</em>/atom.git
 
 From there, you can navigate into the directory where you've cloned the Atom source code and run the bootstrap script to install all the required dependencies:
 
+<span class="platform-mac platform-linux">
+``` command-line
+$ cd <em>where-you-cloned-atom</em>
+$ script/bootstrap
+```
+</span>
+<span class="platform-windows">
 ``` command-line
 $ cd <em>where-you-cloned-atom</em>
 $ script\bootstrap
 ```
+</span>
 
 #### Running in Development Mode
 


### PR DESCRIPTION
calling `script/bootstrap` in command line on Windows displays an error:

```
'script' is not recognized as an internal or external command,
operable program or batch file.
```

The solution is to use backslash instead of forward slash `script\bootstrap`