### PR TITLE
Use correct scope name for addInjectionPoint

### DIFF
--- a/content/hacking-atom/sections/creating-a-grammar.md
+++ b/content/hacking-atom/sections/creating-a-grammar.md
@@ -200,7 +200,7 @@ The `tree-sitter-javascript` parser parses this tagged template literal as a `ca
 Here is an injection point that would allow syntax highlighting inside of template literals:
 
 ```js
-atom.grammars.addInjectionPoint('javascript', {
+atom.grammars.addInjectionPoint('source.js', {
   type: 'call_expression',
 
   language (callExpression) {


### PR DESCRIPTION
The javascript scope name changed from `javascript` to `source.js` in atom/language-javascript#591. The same change was done in atom/language-javascript@ea37ba47038b9e6f253a8a4b22cf7b611e79bf98.