### PR TITLE
Update atom-selections.md

### DIFF
--- a/content/using-atom/sections/atom-selections.md
+++ b/content/using-atom/sections/atom-selections.md
@@ -7,16 +7,16 @@ Text selections in Atom support a number of actions, such as scoping deletion, i
 
 Selections mirror many of the movement commands. They're actually exactly the same keybindings as the movement commands, but with a <kbd class="platform-all">Shift</kbd> key added in.
 
-* <kbd class="platform-all">Shift+Up</kbd><span class="platform-mac"> or <kbd class="platform-mac">Ctrl+Shift+P</kbd></span> - Select up
-* <kbd class="platform-all">Shift+Down</kbd><span class="platform-mac"> or <kbd class="platform-mac">Ctrl+Shift+N</kbd></span> - Select down
-* <kbd class="platform-all">Shift+Left</kbd><span class="platform-mac"> or <kbd class="platform-mac">Ctrl+Shift+B</kbd></span> - Select previous character
-* <kbd class="platform-all">Shift+Right</kbd><span class="platform-mac"> or <kbd class="platform-mac">Ctrl+Shift+F</kbd></span> - Select next character
-* <kbd class="platform-mac">Alt+Shift+Left</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+Left</kbd><span class="platform-mac"> or <kbd class="platform-mac">Alt+Shift+B</kbd></span> - Select to beginning of word
-* <kbd class="platform-mac">Alt+Shift+Right</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+Right</kbd><span class="platform-mac"> or <kbd class="platform-mac">Alt+Shift+F</kbd></span> - Select to end of word
-* <kbd class="platform-mac">Cmd+Shift+Right</kbd><kbd class="platform-windows platform-linux">Shift+End</kbd><span class="platform-mac"> or <kbd class="platform-mac">Ctrl+Shift+E</kbd></span> - Select to end of line
-* <kbd class="platform-mac">Cmd+Shift+Left</kbd><kbd class="platform-windows platform-linux">Shift+Home</kbd><span class="platform-mac"> or <kbd class="platform-mac">Ctrl+Shift+A</kbd></span> - Select to first character of line
-* <kbd class="platform-mac">Cmd+Shift+Up</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+Home</kbd> - Select to top of file
-* <kbd class="platform-mac">Cmd+Shift+Down</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+End</kbd> - Select to bottom of file
+* <kbd class="platform-all">Shift+Up</kbd><span class="platform-mac"> or <kbd class="platform-mac">Shift+Ctrl+P</kbd></span> - Select up
+* <kbd class="platform-all">Shift+Down</kbd><span class="platform-mac"> or <kbd class="platform-mac">Shift+Ctrl+N</kbd></span> - Select down
+* <kbd class="platform-all">Shift+Left</kbd><span class="platform-mac"> or <kbd class="platform-mac">Shift+Ctrl+B</kbd></span> - Select previous character
+* <kbd class="platform-all">Shift+Right</kbd><span class="platform-mac"> or <kbd class="platform-mac">Shift+Ctrl+F</kbd></span> - Select next character
+* <kbd class="platform-mac">Shift+Alt+Left</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+Left</kbd><span class="platform-mac"> or <kbd class="platform-mac">Shift+Alt+B</kbd></span> - Select to beginning of word
+* <kbd class="platform-mac">Shift+Alt+Right</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+Right</kbd><span class="platform-mac"> or <kbd class="platform-mac">Shift+Alt+F</kbd></span> - Select to end of word
+* <kbd class="platform-mac">Shift+Cmd+Right</kbd><kbd class="platform-windows platform-linux">Shift+End</kbd><span class="platform-mac"> or <kbd class="platform-mac">Shift+Ctrl+E</kbd></span> - Select to end of line
+* <kbd class="platform-mac">Shift+Cmd+Left</kbd><kbd class="platform-windows platform-linux">Shift+Home</kbd><span class="platform-mac"> or <kbd class="platform-mac">Shift+Ctrl+A</kbd></span> - Select to first character of line
+* <kbd class="platform-mac">Shift+Cmd+Up</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+Home</kbd> - Select to top of file
+* <kbd class="platform-mac">Shift+Cmd+Down</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+End</kbd> - Select to bottom of file
 
 In addition to the cursor movement selection commands, there are also a few commands that help with selecting specific areas of content.
 


### PR DESCRIPTION
Changed key combination sequence by moving ```Shift``` to the front of sequence. For the reader this emphasise ```Shift``` as concept of selection. Psychologically it is intuitive to start pressing ```Shift``` to select by cursor movement. This also makes the cursor movement key combination more obvious for the analytical user. Exception is ```Ctrl-Shift-W``` which is unchanged because it is special.
This is violation of Atom Flight Manual keybinding rule 7.
I have only made modification for Mac platform to see how it looks.
