### PR TITLE
use wget instead of curl for installing Atom

### DIFF
--- a/content/getting-started/sections/installing-atom.md
+++ b/content/getting-started/sections/installing-atom.md
@@ -78,7 +78,7 @@ To install Atom on Debian, Ubuntu, or related distributions, add our official
 package repository to your system by running the following commands:
 
 ``` command-line
-$ curl -sL https://packagecloud.io/AtomEditor/atom/gpgkey | sudo apt-key add -
+$ wget -qO - https://packagecloud.io/AtomEditor/atom/gpgkey | sudo apt-key add -
 $ sudo sh -c 'echo "deb [arch=amd64] https://packagecloud.io/AtomEditor/atom/any/ any main" > /etc/apt/sources.list.d/atom.list'
 $ sudo apt-get update
 ```


### PR DESCRIPTION
since curl is not installed by default on Ubuntu