### PR TITLE
Convert CoffeeScript code examples to JavaScript

### DIFF
--- a/content/behind-atom/sections/configuration-api.md
+++ b/content/behind-atom/sections/configuration-api.md
@@ -7,24 +7,30 @@ title: Configuration API
 
 If you are writing a package that you want to make configurable, you'll need to read config settings via the `atom.config` global. You can read the current value of a namespaced config key with `atom.config.get`:
 
-```coffeescript
-# read a value with `config.get`
-@showInvisibles() if atom.config.get "editor.showInvisibles"
+```javascript
+// read a value with `config.get`
+if (atom.config.get("editor.showInvisibles")) {
+  this.showInvisibles()
+}
 ```
 
 Or you can subscribe via `atom.config.observe` to track changes from any view object.
 
-```coffeescript
-{View} = require 'space-pen'
+```javascript
+const {View} = require('space-pen')
 
-class MyView extends View
-  attached: ->
-    @fontSizeObserveSubscription =
-      atom.config.observe 'editor.fontSize', (newValue, {previous}) =>
-        @adjustFontSize(newValue)
+class MyView extends View {
+  function attached() {
+    this.fontSizeObserveSubscription =
+      atom.config.observe('editor.fontSize', (newValue, {previous}) => {
+        this.adjustFontSize(newValue)
+      })
+  }
 
-  detached: ->
-    @fontSizeObserveSubscription.dispose()
+  function detached() {
+    this.fontSizeObserveSubscription.dispose()
+  }
+}
 ```
 
 The `atom.config.observe` method will call the given callback immediately with the current value for the specified key path, and it will also call it in the future whenever the value of that key path changes. If you only want to invoke the callback the next time the value changes, use `atom.config.onDidChange` instead.
@@ -35,8 +41,8 @@ Subscription methods return [`Disposable`](https://atom.io/docs/api/latest/Dispo
 
 The `atom.config` database is populated on startup from <span class="platform-mac platform-linux">`~/.atom/config.cson`</span><span class="platform-windows">`%USERPROFILE%\.atom\config.cson`</span>, but you can programmatically write to it with `atom.config.set`:
 
-```coffeescript
-# basic key update
+```javascript
+// basic key update
 atom.config.set("core.showInvisibles", true)
 ```
 

--- a/content/behind-atom/sections/interacting-with-other-packages-via-services.md
+++ b/content/behind-atom/sections/interacting-with-other-packages-via-services.md
@@ -64,12 +64,12 @@ module.exports = {
 
   consumeAnotherServiceV1(service) {
     useService(adaptServiceFromLegacyAPI(service));
-    return new Disposable(function() { return stopUsingService(service) })
+    return new Disposable(() => stopUsingService(service))
   },
 
   consumeAnotherServiceV2(service) {
     useService(service)
-    return new Disposable(function() { return stopUsingService(service) })
+    return new Disposable(() => stopUsingService(service))
   }
 }
 ```

--- a/content/behind-atom/sections/interacting-with-other-packages-via-services.md
+++ b/content/behind-atom/sections/interacting-with-other-packages-via-services.md
@@ -21,15 +21,20 @@ Atom packages can interact with each other through versioned APIs called _servic
 
 In your package's main module, implement the methods named above. These methods will be called any time a package is activated that consumes their corresponding service. They should return a value that implements the service's API.
 
-```coffee
-module.exports =
-  activate: -> # ...
+```javascript
+module.exports = {
+  activate() {
+    // ...
+  },
 
-  provideMyServiceV1: ->
-    adaptToLegacyAPI(myService)
+  provideMyServiceV1() {
+    return adaptToLegacyAPI(myService)
+  },
 
-  provideMyServiceV2: ->
-    myService
+  provideMyServiceV2() {
+    return myService
+  }
+}
 ```
 
 Similarly, to consume a service, specify one or more [version _ranges_](https://docs.npmjs.com/misc/semver#ranges), each paired with the name of a method on the package's main module:
@@ -49,17 +54,22 @@ Similarly, to consume a service, specify one or more [version _ranges_](https://
 
 These methods will be called any time a package is activated that *provides* their corresponding service. They will receive the service object as an argument. You will usually need to perform some kind of cleanup in the event that the package providing the service is deactivated. To do this, return a `Disposable` from your service-consuming method:
 
-```coffee
-{Disposable} = require 'atom'
+```javascript
+const {Disposable} = require('atom');
 
-module.exports =
-  activate: -> # ...
+module.exports = {
+  activate() {
+    // ...
+  },
 
-  consumeAnotherServiceV1: (service) ->
-    useService(adaptServiceFromLegacyAPI(service))
-    new Disposable -> stopUsingService(service)
+  consumeAnotherServiceV1(service) {
+    useService(adaptServiceFromLegacyAPI(service));
+    return new Disposable(function() { return stopUsingService(service) })
+  },
 
-  consumeAnotherServiceV2: (service) ->
+  consumeAnotherServiceV2(service) {
     useService(service)
-    new Disposable -> stopUsingService(service)
+    return new Disposable(function() { return stopUsingService(service) })
+  }
+}
 ```

--- a/content/behind-atom/sections/keymaps-in-depth.md
+++ b/content/behind-atom/sections/keymaps-in-depth.md
@@ -78,11 +78,13 @@ Key combinations express one or more keys combined with optional modifier keys. 
 
 Commands are custom DOM events that are triggered when a key combination or sequence matches a binding. This allows user interface code to listen for named commands without specifying the specific keybinding that triggers it. For example, the following code creates a command to insert the current date in an editor:
 
-```coffee
-atom.commands.add 'atom-text-editor',
-  'user:insert-date': (event) ->
-    editor = @getModel()
-    editor.insertText(new Date().toLocaleString())
+```javascript
+atom.commands.add('atom-text-editor', {
+  'user:insert-date': (event) => {
+    const editor = this.getModel()
+    return editor.insertText(new Date().toLocaleString())
+  }
+})
 ```
 
 `atom.commands` refers to the global `CommandRegistry` instance where all commands are set and consequently picked up by the command palette.
@@ -93,11 +95,12 @@ When you are looking to bind new keys, it is often useful to use the Command Pal
 
 A common question is, "How do I make a single keybinding execute two or more commands?" There isn't any direct support for this in Atom, but it can be achieved by creating a custom command that performs the multiple actions you desire and then creating a keybinding for that command. For example, let's say I want to create a "composed" command that performs a Select Line followed by Cut. You could add the following to your `init.coffee`:
 
-```coffee
-atom.commands.add 'atom-text-editor', 'custom:cut-line', ->
-  editor = atom.workspace.getActiveTextEditor()
+```javascript
+atom.commands.add('atom-text-editor', 'custom:cut-line', function() {
+  const editor = atom.workspace.getActiveTextEditor()
   editor.selectLinesContainingCursors()
   editor.cutSelectedText()
+})
 ```
 
 Then let's say we want to map this custom command to `alt-ctrl-z`, you could add the following to your keymap:
@@ -184,13 +187,15 @@ Occasionally, it makes sense to layer multiple actions on top of the same key bi
 
 To achieve this, the snippets package makes use of the `.abortKeyBinding()` method on the event object representing the `snippets:expand` command.
 
-```coffee-script
-# pseudo-code
-editor.command 'snippets:expand', (e) =>
-  if @cursorFollowsValidPrefix()
-    @expandSnippet()
-  else
+```javascript
+// pseudo-code
+editor.command('snippets:expand', e => {
+  if (this.cursorFollowsValidPrefix()) {
+    this.expandSnippet()
+  } else {
     e.abortKeyBinding()
+  }
+})
 ```
 
 When the event handler observes that the cursor does not follow a valid prefix, it calls `e.abortKeyBinding()`, telling the keymap system to continue searching for another matching binding.

--- a/content/behind-atom/sections/keymaps-in-depth.md
+++ b/content/behind-atom/sections/keymaps-in-depth.md
@@ -96,7 +96,7 @@ When you are looking to bind new keys, it is often useful to use the Command Pal
 A common question is, "How do I make a single keybinding execute two or more commands?" There isn't any direct support for this in Atom, but it can be achieved by creating a custom command that performs the multiple actions you desire and then creating a keybinding for that command. For example, let's say I want to create a "composed" command that performs a Select Line followed by Cut. You could add the following to your `init.coffee`:
 
 ```javascript
-atom.commands.add('atom-text-editor', 'custom:cut-line', function() {
+atom.commands.add('atom-text-editor', 'custom:cut-line', () => {
   const editor = atom.workspace.getActiveTextEditor()
   editor.selectLinesContainingCursors()
   editor.cutSelectedText()

--- a/content/behind-atom/sections/scoped-settings-scopes-and-scope-descriptors.md
+++ b/content/behind-atom/sections/scoped-settings-scopes-and-scope-descriptors.md
@@ -49,7 +49,7 @@ A scope descriptor is an [Object](https://atom.io/docs/api/latest/ScopeDescripto
 
 In our JavaScript example above, a scope descriptor for the function name token would be:
 
-```coffee
+```javascript
 ['source.js', 'meta.function.js', 'entity.name.function.js']
 ```
 

--- a/content/behind-atom/sections/scoped-settings-scopes-and-scope-descriptors.md
+++ b/content/behind-atom/sections/scoped-settings-scopes-and-scope-descriptors.md
@@ -39,8 +39,8 @@ Scope selectors allow you to target specific tokens just like a CSS selector tar
 
 [`Config::set`](https://atom.io/docs/api/latest/Config#instance-set) accepts a `scopeSelector`. If you'd like to set a setting for JavaScript function names, you can give it the JavaScript function name `scopeSelector`:
 
-```coffee
-atom.config.set('my-package.my-setting', 'special value', scopeSelector: '.source.js .function.name')
+```javascript
+atom.config.set('my-package.my-setting', 'special value', {scopeSelector: '.source.js .function.name'})
 ```
 
 #### Scope Descriptors
@@ -55,9 +55,9 @@ In our JavaScript example above, a scope descriptor for the function name token 
 
 [`Config::get`](https://atom.io/docs/api/latest/Config#instance-get) accepts a `scopeDescriptor`. You can get the value for your setting scoped to JavaScript function names via:
 
-```coffee
-scopeDescriptor = ['source.js', 'meta.function.js', 'entity.name.function.js']
-value = atom.config.get('my-package.my-setting', scope: scopeDescriptor)
+```javascript
+const scopeDescriptor = ['source.js', 'meta.function.js', 'entity.name.function.js']
+const value = atom.config.get('my-package.my-setting', {scope: scopeDescriptor})
 ```
 
 But, you do not need to generate scope descriptors by hand. There are a couple methods available to get the scope descriptor from the editor:
@@ -68,9 +68,9 @@ But, you do not need to generate scope descriptors by hand. There are a couple m
 
 Let's revisit our example using these methods:
 
-```coffee
-editor = atom.workspace.getActiveTextEditor()
-cursor = editor.getLastCursor()
-valueAtCursor = atom.config.get('my-package.my-setting', scope: cursor.getScopeDescriptor())
-valueForLanguage = atom.config.get('my-package.my-setting', scope: editor.getRootScopeDescriptor())
+```javascript
+const editor = atom.workspace.getActiveTextEditor()
+const cursor = editor.getLastCursor()
+const valueAtCursor = atom.config.get('my-package.my-setting', {scope: cursor.getScopeDescriptor()})
+const valueForLanguage = atom.config.get('my-package.my-setting', {scope: editor.getRootScopeDescriptor()})
 ```

--- a/content/behind-atom/sections/serialization-in-atom.md
+++ b/content/behind-atom/sections/serialization-in-atom.md
@@ -9,25 +9,33 @@ When a window is refreshed or restored from a previous session, the view and its
 
 Your package's main module can optionally include a `serialize` method, which will be called before your package is deactivated. You should return a JSON-serializable object, which will be handed back to you as an object argument to `activate` next time it is called. In the following example, the package keeps an instance of `MyObject` in the same state across refreshes.
 
-```coffee-script
-module.exports =
-  activate: (state) ->
-    @myObject =
-      if state
-        atom.deserializers.deserialize(state)
-      else
-        new MyObject("Hello")
+```javascript
+module.exports = {
+  activate(state) {
+    this.myObject = state ? atom.deserializers.deserialize(state) : new MyObject("Hello")
+  },
 
-  serialize: ->
-    @myObject.serialize()
+  serialize() {
+    return this.myObject.serialize()
+  }
+}
 ```
 
 #### Serialization Methods
 
-```coffee-script
-class MyObject
-  constructor: (@data) ->
-  serialize: -> { deserializer: 'MyObject', data: @data }
+```javascript
+class MyObject {
+  constructor(data) {
+    this.data = data
+  }
+
+  serialize() {
+    return {
+      deserializer: 'MyObject',
+      data: this.data
+    }
+  }
+}
 ```
 
 ##### `serialize()`
@@ -54,9 +62,12 @@ The preferred way to register deserializers is via your package's `package.json`
 
 Here, the key (`"MyObject"`) is the name of the deserializer—the same string used by the `deserializer` field in the object returned by your `serialize()` method. The value (`"deserializeMyObject"`) is the name of a function in your main module that'll be passed the serialized data and will return a genuine object. For example, your main module might look like this:
 
-```coffee-script
-module.exports =
-  deserializeMyObject: ({data}) -> new MyObject(data)
+```javascript
+module.exports = {
+  deserializeMyObject({data}) {
+    return new MyObject(data)
+  }
+}
 ```
 
 Now you can call the global `deserialize` method with state returned from `serialize`, and your class's `deserialize` method will be selected automatically.
@@ -65,26 +76,56 @@ Now you can call the global `deserialize` method with state returned from `seria
 
 An alternative is to use the `atom.deserializers.add` method with your class in order to make it available to the deserialization system. Usually this is used in conjunction with a class-level `deserialize` method:
 
-```coffee-script
-class MyObject
-  atom.deserializers.add(this)
+```javascript
+class MyObject {
+  static initClass() {
+    atom.deserializers.add(this)
+  }
 
-  @deserialize: ({data}) -> new MyObject(data)
-  constructor: (@data) ->
-  serialize: -> { deserializer: 'MyObject', data: @data }
+  static deserialize({data}) {
+    return new MyObject(data)
+  }
+
+  constructor(data) {
+    this.data = data;
+  }
+
+  serialize() {
+    return {
+      deserializer: 'MyObject',
+      data: this.data
+    }
+  }
+}
+
+MyObject.initClass()
 ```
 
 While this used to be the standard method of registering a deserializer, the `package.json` method is now preferred since it allows Atom to defer loading and executing your code until it's actually needed.
 
 #### Versioning
 
-```coffee-script
-class MyObject
-  atom.deserializers.add(this)
+```javascript
+class MyObject {
+  static initClass() {
+    atom.deserializers.add(this);
 
-  @version: 2
-  @deserialize: (state) -> ...
-  serialize: -> { version: @constructor.version, ... }
+    this.version = 2;
+  }
+
+  static deserialize(state) {
+    // ...
+  }
+
+  serialize() {
+    return {
+      version: this.constructor.version,
+      // ...
+    }
+  }
+}
+
+MyObject.initClass();
 ```
 
 Your serializable class can optionally have a class-level `@version` property and include a `version` key in its serialized state. When deserializing, Atom will only attempt to call deserialize if the two versions match, and otherwise return undefined. We plan on implementing a migration system in the future, but this at least protects you from improperly deserializing old state.

--- a/content/hacking-atom/sections/tools-of-the-trade.md
+++ b/content/hacking-atom/sections/tools-of-the-trade.md
@@ -1,11 +1,12 @@
 ---
 title: Tools of the Trade
 ---
+
 ### Tools of the Trade
 
-To begin, there are a few things we'll assume you know, at least to some degree. Since all of Atom is implemented using web technologies, we have to assume you know web technologies such as JavaScript and CSS. Specifically, we'll be implementing everything in CoffeeScript and Less, which are preprocessors for Javascript and CSS respectively.
+To begin, there are a few things we'll assume you know, at least to some degree. Since all of Atom is implemented using web technologies, we have to assume you know web technologies such as JavaScript and CSS. Specifically, we'll be using Less, which is a preprocessors for CSS.
 
-If you don't know CoffeeScript, but you are familiar with JavaScript, you shouldn't have too much trouble. Here is an example of some simple CoffeeScript code:
+While much of Atom has been converted to JavaScript, a lot of older code has been left implemented in CoffeeScript because changing it would have been too risky. Additionally, Atom's default configuration language is CSON, which is based on CoffeeScript. If you don't know CoffeeScript, but you are familiar with JavaScript, you shouldn't have too much trouble. Here is an example of some simple CoffeeScript code:
 
 ```coffee
 MyPackageView = require './my-package-view'

--- a/content/hacking-atom/sections/tools-of-the-trade.md
+++ b/content/hacking-atom/sections/tools-of-the-trade.md
@@ -4,7 +4,7 @@ title: Tools of the Trade
 
 ### Tools of the Trade
 
-To begin, there are a few things we'll assume you know, at least to some degree. Since all of Atom is implemented using web technologies, we have to assume you know web technologies such as JavaScript and CSS. Specifically, we'll be using Less, which is a preprocessors for CSS.
+To begin, there are a few things we'll assume you know, at least to some degree. Since all of Atom is implemented using web technologies, we have to assume you know web technologies such as JavaScript and CSS. Specifically, we'll be using Less, which is a preprocessor for CSS.
 
 While much of Atom has been converted to JavaScript, a lot of older code has been left implemented in CoffeeScript because changing it would have been too risky. Additionally, Atom's default configuration language is CSON, which is based on CoffeeScript. If you don't know CoffeeScript, but you are familiar with JavaScript, you shouldn't have too much trouble. Here is an example of some simple CoffeeScript code:
 

--- a/content/hacking-atom/sections/writing-specs.md
+++ b/content/hacking-atom/sections/writing-specs.md
@@ -19,37 +19,43 @@ Spec files **must** end with `-spec` so add `sample-spec.coffee` to the `spec` d
 
 The `describe` method takes two arguments, a description and a function. If the description explains a behavior it typically begins with `when`; if it is more like a unit test it begins with the method name.
 
-```coffee
-describe "when a test is written", ->
-  # contents
+```javascript
+describe("when a test is written", function() {
+  // contents
+})
 ```
 
 or
 
-```coffee
-describe "Editor::moveUp", ->
-  # contents
+```javascript
+describe("Editor::moveUp", function() {
+  // contents
+})
 ```
 
 ##### Add One or More `it` Methods
 
 The `it` method also takes two arguments, a description and a function. Try and make the description flow with the `it` method. For example, a description of "this should work" doesn't read well as "it this should work". But a description of "should work" sounds great as "it should work".
 
-```coffee
-describe "when a test is written", ->
-  it "has some expectations that should pass", ->
-    # Expectations
+```javascript
+describe("when a test is written", function() {
+  it("has some expectations that should pass", function() {
+    // Expectations
+  })
+})
 ```
 
 ##### Add One or More Expectations
 
 The best way to learn about expectations is to read the [Jasmine documentation](https://jasmine.github.io/1.3/introduction.html#section-Expectations) about them. Below is a simple example.
 
-```coffee
-describe "when a test is written", ->
-  it "has some expectations that should pass", ->
+```javascript
+describe("when a test is written", function() {
+  it("has some expectations that should pass", function() {
     expect("apples").toEqual("apples")
     expect("oranges").not.toEqual("apples")
+  })
+})
 ```
 
 ###### Custom Matchers
@@ -73,44 +79,47 @@ Writing Asynchronous specs can be tricky at first. Some examples.
 
 Working with promises is rather easy in Atom. You can use our `waitsForPromise` function.
 
-```coffee
-describe "when we open a file", ->
-  it "should be opened in an editor", ->
-    waitsForPromise ->
-      atom.workspace.open('c.coffee').then (editor) ->
-        expect(editor.getPath()).toContain 'c.coffee'
+```javascript
+describe("when we open a file", function() {
+  it("should be opened in an editor", function() {
+    waitsForPromise(function() {
+      atom.workspace.open('c.coffee').then(editor => expect(editor.getPath()).toContain('c.coffee'))
+    })
+  })
+})
 ```
 
 This method can be used in the `describe`, `it`, `beforeEach` and `afterEach` functions.
 
-```coffee
-describe "when we open a file", ->
-  beforeEach ->
-    waitsForPromise ->
-      atom.workspace.open 'c.coffee'
+```javascript
+describe("when we open a file", function() {
+  beforeEach(function() {
+    waitsForPromise(() => atom.workspace.open('c.coffee'))
+  })
 
-  it "should be opened in an editor", ->
-    expect(atom.workspace.getActiveTextEditor().getPath()).toContain 'c.coffee'
-
+  it("should be opened in an editor", function() {
+     expect(atom.workspace.getActiveTextEditor().getPath()).toContain('c.coffee')
+  })
+})
 ```
 
 If you need to wait for multiple promises use a new `waitsForPromise` function for each promise. (Caution: Without `beforeEach` this example will fail!)
 
-```coffee
-describe "waiting for the packages to load", ->
-  beforeEach ->
-    waitsForPromise ->
-      atom.workspace.open('sample.js')
+```javascript
+describe("waiting for the packages to load", function() {
+  beforeEach(function() {
+    waitsForPromise(() => atom.workspace.open('sample.js'))
 
-    waitsForPromise ->
-      atom.packages.activatePackage('tabs')
+    waitsForPromise(() => atom.packages.activatePackage('tabs'))
 
-    waitsForPromise ->
-      atom.packages.activatePackage('tree-view')
+    waitsForPromise(() => atom.packages.activatePackage('tree-view'))
+  });
 
-  it 'should have waited long enough', ->
-    expect(atom.packages.isPackageActive('tabs')).toBe true
-    expect(atom.packages.isPackageActive('tree-view')).toBe true
+  it('should have waited long enough', function() {
+    expect(atom.packages.isPackageActive('tabs')).toBe(true)
+    expect(atom.packages.isPackageActive('tree-view')).toBe(true)
+  })
+})
 ```
 
 `waitsForPromise` can take an additional object argument before the function. The object can have the following properties:
@@ -119,31 +128,36 @@ describe "waiting for the packages to load", ->
 * `timeout` The amount of time (in ms) to wait for the promise to be resolved or rejected (default: `process.env.CI ? 60000 : 5000`)
 * `label` The label to display if promise times out (default: `'promise to be resolved or rejected'`)
 
-```coffee
-describe "when we open a file", ->
-  it "should be opened in an editor", ->
-    waitsForPromise { shouldReject: false, timeout: 5000, label: 'promise to be resolved or rejected' }, ->
-      atom.workspace.open('c.coffee').then (editor) ->
-        expect(editor.getPath()).toContain 'c.coffee'
+```javascript
+describe("when we open a file", function() {
+  it("should be opened in an editor", function() {
+    waitsForPromise({ shouldReject: false, timeout: 5000, label: 'promise to be resolved or rejected' }, () =>
+      atom.workspace.open('c.coffee').then(editor => expect(editor.getPath()).toContain('c.coffee'))
+    )
+  })
+})
 ```
 
 ##### Asynchronous Functions with Callbacks
 
 Specs for asynchronous functions can be done using the `waitsFor` and `runs` functions. A simple example.
 
-```coffee
-describe "fs.readdir(path, cb)", ->
-  it "is async", ->
-    spy = jasmine.createSpy('fs.readdirSpy')
+```javascript
+describe("fs.readdir(path, cb)", function() {
+  it("is async", function() {
+    const spy = jasmine.createSpy('fs.readdirSpy')
     fs.readdir('/tmp/example', spy)
 
-    waitsFor ->
-      spy.callCount > 0
+    waitsFor(() => spy.callCount > 0)
 
-    runs ->
-      exp = [null, ['example.coffee']]
-      expect(spy.mostRecentCall.args).toEqual exp
+    runs(function() {
+      const exp = [null, ['example.coffee']]
+
+      expect(spy.mostRecentCall.args).toEqual(exp)
       expect(spy).toHaveBeenCalledWith(null, ['example.coffee'])
+    })
+  })
+})
 ```
 
 For a more detailed documentation on asynchronous tests please visit the [Jasmine documentation](https://jasmine.github.io/1.3/introduction.html#section-Asynchronous_Support).
@@ -154,11 +168,13 @@ Most of the time you'll want to run specs by triggering the `window:run-package-
 
 To run a limited subset of specs use the `fdescribe` or `fit` methods. You can use those to focus a single spec or several specs. Modified from the example above, focusing an individual spec looks like this:
 
-```coffee
-describe "when a test is written", ->
-  fit "has some expectations that should pass", ->
+```javascript
+describe("when a test is written", function() {
+  fit("has some expectations that should pass", function() {
     expect("apples").toEqual("apples")
     expect("oranges").not.toEqual("apples")
+  })
+})
 ```
 
 ##### Running on CI


### PR DESCRIPTION
This intentionally leaves alone:

* Examples having to do with configuration files
* The chapter on upgrading your package to the Atom v1.0 API (since anything pre-1.0 was in CoffeeScript anyway)
