### PR TITLE
Fix broken emoji URLs

### DIFF
--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -7,7 +7,7 @@ asciidoc_pipeline_config:
     - :HTTPSFilter
   http_url: https://github.com
   base_url: /
-  asset_root: https://a248.e.akamai.net/assets.github.com/images/icons
+  asset_root: https://github.githubassets.com/images/icons
 
 markdown_pipeline_config:
   pipeline:
@@ -18,7 +18,7 @@ markdown_pipeline_config:
     - :HTTPSFilter
   http_url: https://github.com
   base_url: /
-  asset_root: https://a248.e.akamai.net/assets.github.com/images/icons
+  asset_root: https://github.githubassets.com/images/icons
 
 # The syntax to use for patterns in the Rules file. Can be either `"glob"`
 # (default) or `"legacy"`. The former will enable glob patterns, which behave


### PR DESCRIPTION
## Description

Noticed the CI failure in https://github.com/atom/flight-manual.atom.io/pull/513 was the link checker finding broken emoji links:

```
Checking 227 external links...
Ran on 67 files!
- ./output/hacking-atom/sections/creating-a-theme/index.html
  *  External link https://a248.e.akamai.net/assets.github.com/images/icons/emoji/unicode/1f389.png failed: 404 No error
- ./output/hacking-atom/sections/debugging/index.html
  *  External link https://a248.e.akamai.net/assets.github.com/images/icons/emoji/unicode/1f6a8.png failed: 404 No error
- ./output/hacking-atom/sections/package-word-count/index.html
  *  External link https://a248.e.akamai.net/assets.github.com/images/icons/emoji/unicode/1f600.png failed: 404 No error
- ./output/using-atom/sections/snippets/index.html
  *  External link https://a248.e.akamai.net/assets.github.com/images/icons/emoji/unicode/1f4a5.png failed: 404 No error
rake aborted!
HTML-Proofer found 4 failures!
```

The URLs we were using no longer work (not sure when that happened) but it looks like updating the base URL to `https://github.githubassets.com/images/icons` fixes things.  I got the URL after finding jekyll/jemoji#89

## Verification

Checked all the links above after making the change locally and the emoji is no longer a broken image.  E.g. for the current [debugging page](https://flight-manual.atom.io/hacking-atom/sections/debugging/), the 🚨 emoji URL is https://a248.e.akamai.net/assets.github.com/images/icons/emoji/unicode/1f6a8.png:

![broken-light](https://github-slack.s3.amazonaws.com/monosnap/Debugging_2019-03-21_20-49-57.png)

With this fix the URL is https://github.githubassets.com/images/icons/emoji/unicode/1f6a8.png:

![light-is-on](https://github-slack.s3.amazonaws.com/monosnap/Debugging_2019-03-21_20-28-55.png)

Fixes #516 