### PR TITLE
⬇️ bundler@1.16.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,4 +128,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   2.0.2
+   1.16.3


### PR DESCRIPTION
#541 changed `Gemfile.lock`'s bundler version from 1.16.3 to 2.0.2. Our CI build was fine with that change, but [publisher](https://github.com/gjtorikian/publisher) seems to use bundler 1.x, so publishing failed as seen in https://github.com/atom/flight-manual.atom.io/issues/553.

This pull request restores the use of bundler 1.16.3, and I anticipate that this will fix #553.