### PR TITLE
Update find-and-replace.md

### DIFF
--- a/content/using-atom/sections/find-and-replace.md
+++ b/content/using-atom/sections/find-and-replace.md
@@ -34,6 +34,12 @@ You can limit a search to a subset of the files in your project by entering a [g
 
 When you have multiple project folders open, this feature can also be used to search in only one of those folders. For example, if you had the folders `/path1/folder1` and `/path2/folder2` open, you could enter a pattern starting with `folder1` to search only in the first folder.
 
+In the third box, you can specify a directory to search:
+
+![](https://pubwriter.net/images/atomSearch.jpg)
+
+![](https://pubwriter.net/images/searchAtom.jpg)
+
 Press <kbd class="platform-all">Esc</kbd> while focused on the Find and Replace panel to clear the pane from your workspace.
 
 The Find and Replace functionality is implemented in the [find-and-replace](https://github.com/atom/find-and-replace) package and uses the [scandal](https://github.com/atom/scandal) Node module to do the actual searching.


### PR DESCRIPTION
### Description of the Change

Previously, it was unclear to me how to specify a single folder to search when you had multiple folders added to a project. It was not obvious that you could actually type the name of a folder in that box at the bottom (under 'Replace in Project') to refine your search. The screenshot should help others see this option more clearly.

### Release Notes

Added a screenshot to clarify how to perform a 'find and replace' within a single folder.
