### PR TITLE
Clarify information about Portable mode

### DIFF
--- a/content/using-atom/sections/basic-customization.md
+++ b/content/using-atom/sections/basic-customization.md
@@ -254,12 +254,4 @@ Portable Mode is most useful for taking Atom with you, with all your custom sett
 
 With such a setup, Atom will use the same Home directory with the same settings for any machine with this directory syncronized/plugged in.
 
-##### Moving to Portable Mode
-
-Atom provides a command-line parameter option for setting Portable Mode.
-
-``` command-line
-$ atom --portable
-```
-
-Executing atom with the `--portable` option will take the `.atom` directory you have in the default location (`~/.atom`) and copy the relevant contents for your configuration to a new home directory in the Portable Mode location. This enables easily moving from the default location to a portable operation without losing the customization you have already set up.
+In addition, creating a folder called `electronUserData` in `.atom` will prevent atom from using `~\AppData\Roaming\Atom` for a truly portable configuration.


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

The documentation seems incorrect since --portable doesn't seem to exist.
https://discuss.atom.io/t/portable-arg-not-migrating-atom-on-windows/69748

This removes the section at the end that talks about --portable, and also adds a small clarification with regards to `electronUserData` in order to make a fully portable setup.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->


Remove erroneous info about the --portable arg and add a small line about the electronUserData folder.
