### PR TITLE
Update installing-atom.md

### DIFF
--- a/content/getting-started/sections/installing-atom.md
+++ b/content/getting-started/sections/installing-atom.md
@@ -102,6 +102,9 @@ $ sudo dpkg -i atom-amd64.deb
 # Install Atom's dependencies if they are missing
 $ sudo apt-get -f install
 ```
+Both above methods failed on Ubuntu 18.04. The following worked.
+# Install Atom
+$ sudo snap install atom --classic
 
 ##### Red Hat and CentOS (YUM), or Fedora (DNF)
 


### PR DESCRIPTION


### Description of the Change

<!--

The suggested installation methods do not not work for Ubuntu 18.04. 
Added
# Install Atom
$ sudo snap install atom --classic

-->

### Release Notes

<!--

Added installation instructions for Ubuntu 18.04

-->

