### PR TITLE
Fix default keybinding for text reflow

### DIFF
--- a/content/using-atom/sections/editing-and-deleting-text.md
+++ b/content/using-atom/sections/editing-and-deleting-text.md
@@ -21,7 +21,7 @@ There are a handful of cool keybindings for basic text manipulation that might c
 
 {{/mac}}
 
-Atom also has built in functionality to re-flow a paragraph to hard-wrap at a given maximum line length. You can format the current selection to have lines no longer than 80 (or whatever number `editor.preferredLineLength` is set to) characters using <kbd class="platform-mac">Alt+Cmd+Q</kbd><kbd class="platform-windows platform-linux">Alt+Ctrl+Q</kbd>. If nothing is selected, the current paragraph will be reflowed.
+Atom also has built in functionality to re-flow a paragraph to hard-wrap at a given maximum line length. You can format the current selection to have lines no longer than 80 (or whatever number `editor.preferredLineLength` is set to) characters using <kbd class="platform-mac">Alt+Cmd+Q</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+Q</kbd>. If nothing is selected, the current paragraph will be reflowed.
 
 #### Deleting and Cutting
 


### PR DESCRIPTION
### Description of the Change
Fixed a wrong default keybinding mentioned in the docs.

### Release Notes
N/A