### PR TITLE
Changed "git-core" package to "git-all" for Fedora/RHEL

### DIFF
--- a/content/hacking-atom/sections/hacking-on-atom-core.md
+++ b/content/hacking-atom/sections/hacking-on-atom-core.md
@@ -150,13 +150,13 @@ For more details, scroll down to find how to setup a specific Linux distro.
 ###### Fedora 22+
 
 ``` command-line
-$ sudo dnf --assumeyes install make gcc gcc-c++ glibc-devel git-core libsecret-devel rpmdevtools libX11-devel libxkbfile-devel
+$ sudo dnf --assumeyes install make gcc gcc-c++ glibc-devel git-all libsecret-devel rpmdevtools libX11-devel libxkbfile-devel
 ```
 
 ###### Fedora 21 / CentOS / RHEL
 
 ``` command-line
-$ sudo yum install -y make gcc gcc-c++ glibc-devel git-core libsecret-devel rpmdevtools
+$ sudo yum install -y make gcc gcc-c++ glibc-devel git-all libsecret-devel rpmdevtools
 ```
 
 ###### Arch


### PR DESCRIPTION
### Description of the Change

In behavior of https://github.com/atom/atom/pull/13547#issue-100289698 this change the `git-core` to `git-all` to enable the usage of `git submodule`, who is not included in the core package.

### Release Notes

No impact on atom