### PR TITLE
Deprecate OS X 10.10 support to match electron

### DIFF
--- a/content/faq/sections/what-platforms-does-atom-run-on.md
+++ b/content/faq/sections/what-platforms-does-atom-run-on.md
@@ -3,6 +3,6 @@ title: What platforms does Atom run on?
 ---
 ### What platforms does Atom run on?
 
-Prebuilt versions of Atom are available for OS X 10.9 or later, Windows 7 or later, RedHat Linux, and Ubuntu Linux.
+Prebuilt versions of Atom are available for OS X 10.10 or later, Windows 7 or later, RedHat Linux, and Ubuntu Linux.
 
 If you would like to build from source on Windows, Linux, or OS X, see the [Atom README](https://github.com/atom/atom/blob/master/README.md#building) for more information.


### PR DESCRIPTION
According to [this](https://github.com/electron/electron/blob/v6.1.12/docs/tutorial/support.md), electron support 10.10 (Yosemite) as the minimum OS X version