### PR TITLE
Fix #631 - Incorrect keybinding for re-flow

### DIFF
--- a/content/using-atom/sections/editing-and-deleting-text.md
+++ b/content/using-atom/sections/editing-and-deleting-text.md
@@ -21,7 +21,7 @@ There are a handful of cool keybindings for basic text manipulation that might c
 
 {{/mac}}
 
-Atom also has built in functionality to re-flow a paragraph to hard-wrap at a given maximum line length. You can format the current selection to have lines no longer than 80 (or whatever number `editor.preferredLineLength` is set to) characters using <kbd class="platform-mac">Alt+Cmd+Q</kbd><kbd class="platform-windows platform-linux">Alt+Ctrl+Q</kbd>. If nothing is selected, the current paragraph will be reflowed.
+Atom also has built in functionality to re-flow a paragraph to hard-wrap at a given maximum line length. You can format the current selection to have lines no longer than 80 (or whatever number `editor.preferredLineLength` is set to) characters using <kbd class="platform-mac">Alt+Cmd+Q</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+Q</kbd>. If nothing is selected, the current paragraph will be reflowed.
 
 #### Deleting and Cutting
 


### PR DESCRIPTION
### Description of the Change

The keybinding for re-flow in the flight manual does not match the default of the autoflow package defined here:

https://github.com/atom/atom/blob/c663022bd91175fd716e36c2e2fc420edc1ea069/packages/autoflow/keymaps/autoflow.cson#L4-L5

This pull request fixes the discrepancy and closes #631.

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Release Notes

N/A

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->
