### PR TITLE
Update Debian/Ubuntu section of installing-atom.d

### DIFF
--- a/content/getting-started/sections/installing-atom.md
+++ b/content/getting-started/sections/installing-atom.md
@@ -78,7 +78,7 @@ To install Atom on Debian, Ubuntu, or related distributions, add our official
 package repository to your system by running the following commands:
 
 ``` command-line
-$ wget -qO - https://packagecloud.io/AtomEditor/atom/gpgkey | sudo apt-key add -
+$ wget -qO - https://packagecloud.io/AtomEditor/atom/gpgkey | gpg --dearmor | sudo tee /usr/share/keyrings/atom-archive-keyring.gpg
 $ sudo sh -c 'echo "deb [arch=amd64] https://packagecloud.io/AtomEditor/atom/any/ any main" > /etc/apt/sources.list.d/atom.list'
 $ sudo apt-get update
 ```


### PR DESCRIPTION
### Description of the Change

In your detailed Debian/Ubuntu installation guide, the command `apt-key` is used. This command is being deprecated. Instead, I'd like to suggest this more future-proof option, using `gpg --dearmor | sudo tee /usr/share/keyrings/atom-archive-keyring.gpg`. Please tell me if there are any modifications you'd like me to make.

### Release Notes

N/A
