### PR TITLE
Updated installation command for .deb package

### DIFF
--- a/content/getting-started/sections/installing-atom.md
+++ b/content/getting-started/sections/installing-atom.md
@@ -97,10 +97,7 @@ Alternatively, you can download the [Atom .deb package](https://atom.io/download
 
 ``` command-line
 # Install Atom
-$ sudo dpkg -i atom-amd64.deb
-
-# Install Atom's dependencies if they are missing
-$ sudo apt-get -f install
+$ sudo apt install ./atom-amd64.deb
 ```
 
 ##### Red Hat and CentOS (YUM), or Fedora (DNF)


### PR DESCRIPTION
The current setup involves running `dpkg -i` to install the `.deb` file, followed by `apt-get -f` to install dependencies.

This can be combined into a single step by just using `sudo apt install ./atom-amd64.deb`, which will install both the Atom package and dependencies in one command.