### PR TITLE
Fix/update missing links

### DIFF
--- a/content/faq/sections/atom-in-the-cloud.md
+++ b/content/faq/sections/atom-in-the-cloud.md
@@ -3,4 +3,4 @@ title: Atom in the cloud?
 ---
 ### Atom in the cloud?
 
-The Atom team has no plans to make a cloud- or server-based version of Atom. For discussion of the idea, see the [Atom message board topic](https://discuss.atom.io/t/can-atom-move-my-workspace-to-cloud-someday/1582).
+The Atom team has no plans to make a cloud- or server-based version of Atom. For discussion of the idea, see the [Atom message board](https://github.com/atom/atom/discussions).

--- a/content/faq/sections/how-do-i-preview-web-page-changes-automatically.md
+++ b/content/faq/sections/how-do-i-preview-web-page-changes-automatically.md
@@ -9,5 +9,3 @@ There are a couple different approaches, for example:
 * [livereload](https://atom.io/packages/livereload) gives you a preview in any browser, but requires you to save the file first.
 
 Other packages may be available now, you can search for Atom packages on the [packages site](https://atom.io/packages).
-
-*HT to @Alchiadus for [this post](https://discuss.atom.io/t/live-preview-without-saving-the-files/20571/2?u=leedohm).*

--- a/content/faq/sections/i-have-a-question-about-a-specific-atom-community-package-where-is-the-best-place-to-ask-it.md
+++ b/content/faq/sections/i-have-a-question-about-a-specific-atom-community-package-where-is-the-best-place-to-ask-it.md
@@ -7,4 +7,4 @@ The best place to get a question answered quickly is probably the Issues list fo
 
 ![Bugs button link](../../images/package-issue-link.png)
 
-And you can always ask Atom-related questions in the [support category](https://discuss.atom.io/c/support) of the [official Atom message board](https://discuss.atom.io). Someone here may know the answer! It's just with over 3,500 packages (as of early February 2016), the forum members may not know all answers for all packages :grinning:
+And you can always ask Atom-related questions in the [official Atom message board](https://github.com/atom/atom/discussions). Someone here may know the answer! It's just with over 3,500 packages (as of early February 2016), the forum members may not know all answers for all packages :grinning:

--- a/content/faq/sections/macos-mojave-font-rendering-change.md
+++ b/content/faq/sections/macos-mojave-font-rendering-change.md
@@ -3,7 +3,7 @@ title: MacOS Mojave font rendering change
 ---
 ### MacOS Mojave font rendering change
 
-In [macOS Mojave v10.14.x](https://www.apple.com/macos/mojave/), Apple disabled [subpixel antialiasing](https://discuss.atom.io/t/how-can-i-tell-if-subpixel-antialiasing-is-working/18586) on all monitors by default. Previous to Mojave, subpixel antialiasing was disabled only on Retina displays or on all displays if the "LCD font smoothing" option was disabled in System Preferences. With this change in Mojave, some users have reported that [their fonts in Atom appear "thinner" or "dimmer" than they did previously.](https://github.com/atom/atom/issues/17486) It can look better or worse depending on your font and theme selections, but in all cases this is completely a side-effect of the change that Apple made to their font rendering and is outside Atom's and Electron's control.
+In [macOS Mojave v10.14.x](https://www.apple.com/macos/mojave/), Apple disabled subpixel antialiasing on all monitors by default. Previous to Mojave, subpixel antialiasing was disabled only on Retina displays or on all displays if the "LCD font smoothing" option was disabled in System Preferences. With this change in Mojave, some users have reported that [their fonts in Atom appear "thinner" or "dimmer" than they did previously.](https://github.com/atom/atom/issues/17486) It can look better or worse depending on your font and theme selections, but in all cases this is completely a side-effect of the change that Apple made to their font rendering and is outside Atom's and Electron's control.
 
 If this change is something that you dislike, there are a couple workarounds that the community has identified.
 

--- a/content/faq/sections/what-is-this-line-on-the-right-in-the-editor-view.md
+++ b/content/faq/sections/what-is-this-line-on-the-right-in-the-editor-view.md
@@ -7,4 +7,4 @@ title: What is this line on the right in the editor view?
 
 That's the wrap guide. It is a visual indicator of when your lines of code are getting too long. It defaults to the column that your Preferred Line Length is set to.
 
-If you want to turn it off, you can [disable the wrap-guide package](https://discuss.atom.io/t/how-do-i-disable-a-package/18183) in the Settings View.
+If you want to turn it off, you can disable the wrap-guide package in the Settings View.

--- a/content/hacking-atom/sections/debugging.md
+++ b/content/hacking-atom/sections/debugging.md
@@ -55,7 +55,7 @@ This starts Atom, but does not load packages from `~/.atom/packages` or `~/.atom
 
 If removing or commenting out all content from the init script and starting Atom normally still produces the error, then try figuring out which package is causing trouble. Start Atom normally again and open the Settings View with <kbd class="platform-mac">Cmd+,</kbd><kbd class="platform-windows platform-linux">Ctrl+,</kbd>. Since the Settings View allows you to disable each installed package, you can disable packages one by one until you can no longer reproduce the issue. Restart Atom or reload Atom with <kbd class="platform-mac">Alt+Cmd+Ctrl+L</kbd><kbd class="platform-windows platform-linux">Ctrl+Shift+F5</kbd> after you disable each package to make sure it's completely gone.
 
-When you find the problematic package, you can disable or uninstall the package. We strongly recommend creating an issue on the package's GitHub repository. The [Atom FAQ](https://discuss.atom.io/c/faq) has information on [how to contact the maintainers of any Atom community package or theme](https://discuss.atom.io/t/i-have-a-question-about-a-specific-atom-community-package-where-is-the-best-place-to-ask-it/25581).
+When you find the problematic package, you can disable or uninstall the package. We strongly recommend creating an issue on the package's GitHub repository.
 
 #### Clearing Saved State
 
@@ -192,7 +192,7 @@ If multiple keybindings are matched, Atom determines which keybinding will be ex
 
 Atom loads core Atom keybindings and package keybindings first, and user-defined keybindings last. Since user-defined keybindings are loaded last, you can use your `keymap.cson` file to tweak the keybindings and sort out problems like these. See the [Keymaps in Depth section](/behind-atom/sections/keymaps-in-depth/) for more information.
 
-If you notice that a package's keybindings are taking precedence over core Atom keybindings, it might be a good idea to report the issue on that package's GitHub repository. The [Atom FAQ](https://discuss.atom.io/c/faq) has information on [how to contact the maintainers of any Atom community package or theme](https://discuss.atom.io/t/i-have-a-question-about-a-specific-atom-community-package-where-is-the-best-place-to-ask-it/25581).
+If you notice that a package's keybindings are taking precedence over core Atom keybindings, it might be a good idea to report the issue on that package's GitHub repository. You can contact atom maintainers on [Atom's github discussions](https://github.com/atom/atom/discussions)
 
 #### Check Font Rendering Issues
 
@@ -321,4 +321,3 @@ Be sure to use Chromium flags at the end of the terminal call if you want to use
 ``` command-line
 $ atom --safe --enable-gpu-rasterization --force-gpu-rasterization
 ```
-

--- a/layouts/includes/top_bar.html
+++ b/layouts/includes/top_bar.html
@@ -7,7 +7,7 @@
       <li><a href="https://atom.io/themes">Themes</a></li>
       <li><a href="https://atom.io/docs" class="is-selected">Documentation</a></li>
       <li><a href="https://blog.atom.io">Blog</a></li>
-      <li><a href="https://discuss.atom.io">Discuss</a></li>
+      <li><a href="https://github.com/atom/atom/discussions">Discussions</a></li>
     </ul>
 
   </div>


### PR DESCRIPTION
PRs updates/fixes links pointing to `discuss.atom.io` which has been sunset