### PR TITLE
Update package-modifying-text.md

### DIFF
--- a/content/hacking-atom/sections/package-modifying-text.md
+++ b/content/hacking-atom/sections/package-modifying-text.md
@@ -115,7 +115,7 @@ Now we need to convert the selected text to ASCII art. To do this we will use th
 
 ```json
 "dependencies": {
-  "figlet": "1.0.8"
+  "figlet": "1.5.2"
 }
 ```
 
@@ -132,7 +132,7 @@ convert () {
     const selection = editor.getSelectedText()
 
     const figlet = require('figlet')
-    const font = 'o8'
+    const font = 'O8'
     figlet(selection, {font}, function (error, art) {
       if (error) {
         console.error(error)


### PR DESCRIPTION
### Description of the Change

I fixed a bug (older font name?) in the convert() function, which tries to use font  `o8` instead of `O8`. I'm not sure if this was the older name of the font, but `O8` is the current name at least as of figlet version 1.5.2. Also, updated the figlet version to the current one, 1.5.2.

### Release Notes

Updated the version of figlet and the name of the imported font.