### PR TITLE
add: add Pacstall to installation options

### DIFF
--- a/content/getting-started/sections/installing-atom.md
+++ b/content/getting-started/sections/installing-atom.md
@@ -99,6 +99,11 @@ Alternatively, you can download the [Atom .deb package](https://atom.io/download
 # Install Atom
 $ sudo apt install ./atom-amd64.deb
 ```
+Another way to install Atom is with [Pacstall](https://pacstall.dev/):
+
+```command-line
+$ pacstall -I atom-editor-deb
+```
 
 ##### Red Hat and CentOS (YUM), or Fedora (DNF)
 


### PR DESCRIPTION
### Description of the Change
Add Pacstall (https://pacstall.dev/) as another way of installing Atom on Debian/Ubuntu.
### Release Notes
- Add Pacstall to list of install options for Debian/Ubuntu.